### PR TITLE
Remove PremiumPrice from DomainTransfer response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Changelog
-
-## master
-
-- REMOVED: Removed PremiumPrice attribute from registrar order responses. Please do not rely on that attribute, as it returned an incorrect value. The attribute is going to be removed, and the API now returns a null value. The TransferDomain now accepts a DomainTransferInput object instead of a DomainTransfer. (dnsimple/dnsimple-csharp#7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## master
+
+- REMOVED: Removed PremiumPrice attribute from registrar order responses. Please do not rely on that attribute, as it returned an incorrect value. The attribute is going to be removed, and the API now returns a null value. The TransferDomain now accepts a DomainTransferInput object instead of a DomainTransfer. (dnsimple/dnsimple-csharp#7)

--- a/src/dnsimple-test/Services/RegistrarTest.cs
+++ b/src/dnsimple-test/Services/RegistrarTest.cs
@@ -157,7 +157,7 @@ namespace dnsimple_test.Services
         {
             var client = new MockDnsimpleClient(TransferDomainFixture);
 
-            var transfer = new DomainTransfer
+            var transfer = new DomainTransferInput
             {
                 RegistrantId = 2,
                 AuthCode = "authcode"
@@ -182,7 +182,7 @@ namespace dnsimple_test.Services
             var client =
                 new MockDnsimpleClient(TransferDomainMissingAuthCodeFixture);
 
-            var transfer = new DomainTransfer
+            var transfer = new DomainTransferInput
             {
                 RegistrantId = 2
             };
@@ -206,7 +206,7 @@ namespace dnsimple_test.Services
                 new MockDnsimpleClient(TransferDomainMissingAuthCodeFixture);
             client.StatusCode(HttpStatusCode.BadRequest);
 
-            var transfer = new DomainTransfer
+            var transfer = new DomainTransferInput
             {
                 RegistrantId = 2,
                 AuthCode = ""
@@ -229,7 +229,7 @@ namespace dnsimple_test.Services
                 new MockDnsimpleClient(TransferDomainErrorInDnsimpleFixture);
             client.StatusCode(HttpStatusCode.BadRequest);
 
-            var transfer = new DomainTransfer
+            var transfer = new DomainTransferInput
             {
                 RegistrantId = 2,
                 AuthCode = "gimmegoogle"

--- a/src/dnsimple/Services/Registrar.cs
+++ b/src/dnsimple/Services/Registrar.cs
@@ -100,16 +100,16 @@ namespace dnsimple.Services
         /// <see cref="DomainTransfer"/>
         /// <see>https://developer.dnsimple.com/v2/registrar/#transferDomain</see>
         public SimpleDnsimpleResponse<DomainTransfer> TransferDomain(long accountId,
-            string domainName, DomainTransferInput transfer)
+            string domainName, DomainTransferInput transferInput)
         {
-            if (transfer.AuthCode == null)
+            if (transferInput.AuthCode == null)
             {
                 throw new DnSimpleException("Please provide an AuthCode");
             }
             var builder = BuildRequestForPath(
                     DomainTransferPath(accountId, domainName));
             builder.Method(Method.POST);
-            builder.AddJsonPayload(transfer);
+            builder.AddJsonPayload(transferInput);
 
             return new SimpleDnsimpleResponse<DomainTransfer>(
                 Execute(builder.Request));

--- a/src/dnsimple/Services/Registrar.cs
+++ b/src/dnsimple/Services/Registrar.cs
@@ -100,7 +100,7 @@ namespace dnsimple.Services
         /// <see cref="DomainTransfer"/>
         /// <see>https://developer.dnsimple.com/v2/registrar/#transferDomain</see>
         public SimpleDnsimpleResponse<DomainTransfer> TransferDomain(long accountId,
-            string domainName, DomainTransfer transfer)
+            string domainName, DomainTransferInput transfer)
         {
             if (transfer.AuthCode == null)
             {
@@ -211,7 +211,7 @@ namespace dnsimple.Services
     }
 
     /// <summary>
-    /// Represents the data sent to the API when transferring a domain.
+    /// Represents a domain transfer.
     /// </summary>
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy),
         ItemNullValueHandling = NullValueHandling.Ignore)]
@@ -219,17 +219,16 @@ namespace dnsimple.Services
     {
         public long Id { get; set; }
         public long DomainId { get; set; }
-        
+
         [JsonProperty(Required = Required.Always)]
         public long RegistrantId { get; set; }
 
         public string State { get; set; }
         public bool AutoRenew { get; set; }
         public bool WhoisPrivacy { get; set; }
-        
+
         public string AuthCode { get; set; }
-        public string PremiumPrice { get; set; }
-        
+
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
     }
@@ -270,4 +269,21 @@ namespace dnsimple.Services
         public long Period { get; set; }
         public string PremiumPrice { get; set; }
     }
+
+    /// <summary>
+    /// Represents the data sent to transfer a domain.
+    /// </summary>
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
+    public struct DomainTransferInput
+    {
+        [JsonProperty(Required = Required.Always)]
+        public long RegistrantId { get; set; }
+
+        public bool AutoRenew { get; set; }
+        public bool WhoisPrivacy { get; set; }
+
+        public string AuthCode { get; set; }
+        public string PremiumPrice { get; set; }
+    }
+
 }


### PR DESCRIPTION
Premium price field will be deprecated in the API, so we should remove
it from the response. This commit changes the TransferDomain method to
accept a new model called DomainTransferInput that contains only the
needed attributes to make the request and remove the PremiumPrice from
the DomainTransfer model that will be responded from the method.