### PR TITLE
Removes required Fax on Contact creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## master
 
+- CHANGED: `Contact.Fax` is not required anymore. (dnsimple/dnsimple-csharp#16)
 - CHANGED: `Certificate.ExpiresOn` has been replaced by `Certificate.ExpiresAt`. (dnsimple/dnsimple-csharp#14)
 - CHANGED: `Domain.ExpiresOn` has been replaced by `Domain.ExpiresAt`. (dnsimple/dnsimple-csharp#11)
 

--- a/src/dnsimple-test/Services/ContactsTest.cs
+++ b/src/dnsimple-test/Services/ContactsTest.cs
@@ -151,7 +151,6 @@ namespace dnsimple_test.Services
         [TestCase("First", null, "first@example.com", "+18001234567", "+18011234567", "Italian Street, 10", "Roma", "RM", "00100", "IT")]
         [TestCase("First", "User", null, "+18001234567", "+18011234567", "Italian Street, 10", "Roma", "RM", "00100", "IT")]
         [TestCase("First", "User", "first@example.com", null, "+18011234567", "Italian Street, 10", "Roma", "RM", "00100", "IT")]
-        [TestCase("First", "User", "first@example.com", "+18001234567", null, "Italian Street, 10", "Roma", "RM", "00100", "IT")]
         [TestCase("First", "User", "first@example.com", "+18001234567", "+18011234567", null, "Roma", "RM", "00100", "IT")]
         [TestCase("First", "User", "first@example.com", "+18001234567", "+18011234567", "Italian Street, 10", null, "RM", "00100", "IT")]
         [TestCase("First", "User", "first@example.com", "+18001234567", "+18011234567", "Italian Street, 10", "Roma", null, "00100", "IT")]

--- a/src/dnsimple/Services/Contacts.cs
+++ b/src/dnsimple/Services/Contacts.cs
@@ -129,7 +129,6 @@ namespace dnsimple.Services
         [JsonProperty(Required = Required.Always)]
         public string Phone { get; set; }
 
-        [JsonProperty(Required = Required.Always)]
         public string Fax { get; set; }
 
         [JsonProperty(Required = Required.Always)]


### PR DESCRIPTION
As said in https://developer.dnsimple.com/v2/contacts/#createContact, Fax field is not required to create a Contact.

