### PR TITLE
Update CHANGELOG for recently introduced ExpiresAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## master
+Incompatible changes:
+
+CHANGED: Certificate.ExpiresOn has been replaced by Certificate.ExpiresAt. (dnsimple/dnsimple-csharp#14)
+CHANGED: Domain.ExpiresOn has been replaced by Domain.ExpiresAt. (dnsimple/dnsimple-csharp#11)
+
 ## Release 0.9.0
 
 Initial non-development release that supports API v2.


### PR DESCRIPTION
We removed Domain and Certificate ExpiresOn attribute in favor of
ExpiresAt. This commit add the missing Changelog entries for this
information.