### PR TITLE
Remove the deprecated Name field from the Certificate data class

### DIFF
--- a/src/dnsimple-test/Services/CertificatesTest.cs
+++ b/src/dnsimple-test/Services/CertificatesTest.cs
@@ -74,7 +74,6 @@ namespace dnsimple_test.Services
                 Assert.AreEqual(101973, certificate.First().Id);
                 Assert.AreEqual(14279, certificate.First().DomainId);
                 Assert.AreEqual(11435, certificate.First().ContactId);
-                Assert.AreEqual("www2", certificate.First().Name);
                 Assert.AreEqual("www2.dnsimple.us", certificate.First().CommonName);
                 Assert.AreEqual(1, certificate.First().Years);
                 Assert.AreEqual(expectedCSR, certificate.First().Csr);
@@ -173,7 +172,6 @@ namespace dnsimple_test.Services
                 Assert.AreEqual(101967, certificate.Id);
                 Assert.AreEqual(289333, certificate.DomainId);
                 Assert.AreEqual(2511, certificate.ContactId);
-                Assert.AreEqual("www", certificate.Name);
                 Assert.AreEqual("www.bingo.pizza", certificate.CommonName);
                 Assert.AreEqual(1, certificate.Years);
                 Assert.AreEqual(expectedCertificate, certificate.Csr);
@@ -373,7 +371,6 @@ namespace dnsimple_test.Services
                 Assert.AreEqual(101967, certificate.Id);
                 Assert.AreEqual(289333, certificate.DomainId);
                 Assert.AreEqual(2511, certificate.ContactId);
-                Assert.AreEqual("www", certificate.Name);
                 Assert.AreEqual("www.bingo.pizza", certificate.CommonName);
                 Assert.AreEqual(1, certificate.Years);
                 Assert.IsNull(certificate.Csr);
@@ -440,7 +437,6 @@ namespace dnsimple_test.Services
                 Assert.AreEqual(101972, renewalIssued.Id);
                 Assert.AreEqual(289333, renewalIssued.DomainId);
                 Assert.AreEqual(2511, renewalIssued.ContactId);
-                Assert.AreEqual("www", renewalIssued.Name);
                 Assert.AreEqual("www.bingo.pizza", renewalIssued.CommonName);
                 Assert.AreEqual(1, renewalIssued.Years);
                 Assert.IsNull(renewalIssued.Csr);

--- a/src/dnsimple/Services/Certificates.cs
+++ b/src/dnsimple/Services/Certificates.cs
@@ -203,7 +203,6 @@ namespace dnsimple.Services
         public long Id { get; set; }
         public long DomainId { get; set; }
         public long ContactId { get; set; }
-        public string Name { get; set; }
         public string CommonName { get; set; }
         public long Years { get; set; }
         public string Csr { get; set; }


### PR DESCRIPTION
This PR removes the deprecated `Name` property from the `Certificate` data class

This should be considered a breaking change, although we could argue that in this client's case, it could be safe to ship without bumping the major version. If this is not acceptable, we should change this PR to deprecate the property instead.