### PR TITLE
Avoids setting UserAgent on ChangeBaseUrlTo when using 

### DIFF
--- a/src/dnsimple-test/ClientTest.cs
+++ b/src/dnsimple-test/ClientTest.cs
@@ -107,5 +107,19 @@ namespace dnsimple_test
 
             Assert.AreEqual($"MySuperAPP {Client.DefaultUserAgent}", _client.UserAgent);
         }
+
+        [Test, Description("https://github.com/dnsimple/dnsimple-csharp/issues/21")]
+        public void AvoidSettingUserAgentOnChangeBaseUrlTo()
+        {
+            var restClientWrapper = new RestClientWrapper();
+            var client = new Client(restClientWrapper);
+
+            client.SetUserAgent("MySuperAPP");
+            var userAgent = restClientWrapper.RestClient.UserAgent;
+
+            client.ChangeBaseUrlTo("https://api.sandbox.dnsimple.com");
+            
+            Assert.AreEqual(userAgent, restClientWrapper.RestClient.UserAgent);
+        }
     }
 }

--- a/src/dnsimple/DNSimple.cs
+++ b/src/dnsimple/DNSimple.cs
@@ -333,7 +333,6 @@ namespace dnsimple
         {
             BaseUrl = baseUrl;
             RestClientWrapper.RestClient.BaseUrl = new Uri(VersionedBaseUrl());
-            RestClientWrapper.RestClient.UserAgent = DefaultUserAgent;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #21 

Avoids setting UserAgent on ChangeBaseUrlTo if Client is provided with a RestClientWrapper

We should release this as a patch once merged.
