### PR TITLE
Update ZoneRecords.cs

### DIFF
--- a/src/dnsimple/Services/ZoneRecords.cs
+++ b/src/dnsimple/Services/ZoneRecords.cs
@@ -135,6 +135,7 @@ namespace dnsimple.Services
         ALIAS,
         CAA,
         CNAME,
+        CDNSKEY,
         DNSKEY,
         DS,
         HINFO,


### PR DESCRIPTION
Added missing ZoneRecordType CDNSKEY

var zones = client.Zones.ListZones(account.Id);
foreach (var zone in zones.Data)
{
   ...
   var records = client.Zones.ListZoneRecords(account.Id, zone.Id.ToString()).Data;
   ...
}

results in:

Newtonsoft.Json.JsonSerializationException: Error converting value "CDNSKEY" to type 'dnsimple.Services.ZoneRecordType'. Path '[18].type'.