### PR TITLE
Adds missing CDNSKEY & CDS record types

### DIFF
--- a/src/dnsimple/Services/ZoneRecords.cs
+++ b/src/dnsimple/Services/ZoneRecords.cs
@@ -134,6 +134,8 @@ namespace dnsimple.Services
         AAAA,
         ALIAS,
         CAA,
+        CDNSKEY,
+        CDS,
         CNAME,
         DNSKEY,
         DS,


### PR DESCRIPTION
Closes https://github.com/dnsimple/dnsimple-csharp/pull/31 (as it is based on it)

CDNSKEY & CDS record types are missing from the ZoneRecordType enum. This PR adds them.

Co-Authored-By: Geert Van Huychem <geert@exira.com> Thanks @VanHuychemG! ❤️ 