### PR TITLE
Handle BadRequest without "errors"

### DIFF
--- a/src/dnsimple/Services/Http.cs
+++ b/src/dnsimple/Services/Http.cs
@@ -81,7 +81,7 @@ namespace dnsimple.Services
                 case HttpStatusCode.BadRequest:
                     if(error["errors"] != null)
                         throw new DnsimpleValidationException(error);
-                    break;
+                    throw new DnsimpleException(message);
                 case HttpStatusCode.NotFound:
                     throw new NotFoundException(message);
                 case HttpStatusCode.PaymentRequired:


### PR DESCRIPTION
BadRequest response without "errors" present, should also be handled here, otherwise the deserialization ("data") fails further down the process.