### PR TITLE
Add JSON payload without serialization

### DIFF
--- a/src/dnsimple/RequestBuilder.cs
+++ b/src/dnsimple/RequestBuilder.cs
@@ -74,6 +74,13 @@ namespace dnsimple
         /// body of the request.</param>
         public void AddJsonPayload(object payload)
             => Request.AddJsonBody(JsonConvert.SerializeObject(payload));
+        
+        /// <summary>
+        /// Adds a JSON payload to the body of the request.
+        /// </summary>
+        /// <param name="payload">The object to be send in the body of the request.</param>
+        public void AddJsonPayloadRaw(object payload)
+            => Request.AddJsonBody(payload);       
 
         /// <summary>
         /// Sets the HTTP method to be used.

--- a/src/dnsimple/Services/RegistrarDelegation.cs
+++ b/src/dnsimple/Services/RegistrarDelegation.cs
@@ -38,7 +38,7 @@ namespace dnsimple.Services
         {
             var builder = BuildRequestForPath(DelegationPath(accountId, domain));
             builder.Method(Method.PUT);
-            builder.AddJsonPayload(delegation);
+            builder.AddJsonPayloadRaw(delegation);
 
             return new DelegationResponse(Execute(builder.Request));
         }
@@ -55,7 +55,7 @@ namespace dnsimple.Services
         {
             var builder = BuildRequestForPath(VanityDelegationPath(accountId, domain));
             builder.Method(Method.PUT);
-            builder.AddJsonPayload(delegation);
+            builder.AddJsonPayloadRaw(delegation);
 
             return new ListResponse<VanityDelegation>(Execute(builder.Request));
         }


### PR DESCRIPTION
Add JSON payload method without serialization first to prevent string arrays/list being escaped in the request.

![image](https://user-images.githubusercontent.com/5196293/101280236-4c6b0100-37c8-11eb-962f-9a048430dc87.png)
