### PR TITLE
Moves documentation to `main` branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
-## master
+## main
 
 - FIXED: Adds missing CDNSKEY & CDS record types (#32). (dnsimple/dnsimple-csharp#32)
 - FIXED: Avoids setting `UserAgent` on `ChangeBaseUrlTo` if Client is provided. (dnsimple/dnsimple-csharp#22)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,11 @@ The following instructions uses `$VERSION` as a placeholder, where `$VERSION` is
     [assembly: AssemblyFileVersion("$VERSION")]
     ```
 3. Run the test suite and ensure all tests pass (`./build.sh`).
-4. Finalize the `## master` section in `CHANGELOG.md` assigning the version.
+4. Finalize the `## main` section in `CHANGELOG.md` assigning the version.
 5. Commit and push the changes
     ```shell
     git commit -a -m "Release $VERSION"
-    git push origin master
+    git push origin main
     ```
 6. Wait for the CI to complete.
 7. Create a signed tag.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A C# client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
-[![Build Status](https://travis-ci.com/dnsimple/dnsimple-csharp.svg?branch=master)](https://travis-ci.com/dnsimple/dnsimple-csharp)
+[![Build Status](https://travis-ci.com/dnsimple/dnsimple-csharp.svg?branch=main)](https://travis-ci.com/dnsimple/dnsimple-csharp)
 
 
 ## Installation
@@ -92,10 +92,10 @@ var domain = client.Domains.GetDomain(accountId, domainId).Data;
 
 ## Sandbox Environment
 
-We highly recommend testing against our [sandbox environment](https://developer.dnsimple.com/sandbox/) before using our production environment. 
+We highly recommend testing against our [sandbox environment](https://developer.dnsimple.com/sandbox/) before using our production environment.
 This will allow you to avoid real purchases, live charges on your credit card, and reduce the chance of your running up against rate limits.
 
-The client supports both the production and sandbox environment. 
+The client supports both the production and sandbox environment.
 To switch to sandbox pass the sandbox API host using the `ChangeBaseUrlTo(...)` method when you construct the client:
 
 ```c#

--- a/src/dnsimple/dnsimple.nuspec
+++ b/src/dnsimple/dnsimple.nuspec
@@ -9,7 +9,7 @@
     <icon>icon.png</icon>
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <repository type="Github" url="https://github.com/dnsimple/dnsimple-csharp" branch="master"/>
+    <repository type="Github" url="https://github.com/dnsimple/dnsimple-csharp" branch="main"/>
     <projectUrl>https://github.com/dnsimple/dnsimple-csharp</projectUrl>
     <description>The DNSimple API client for the .NET platform.</description>
     <summary>The DNSimple API client for C#.</summary>


### PR DESCRIPTION
This PR accommodates documentation and links to the corresponding new `main` default branch

Blocked by the actual task of renaming this repo default branch to `main`