### PR TITLE
Add support for key-data interface creating delegation signer records

### DIFF
--- a/src/dnsimple-test/Services/DomainsDelegationSignerRecordsTest.cs
+++ b/src/dnsimple-test/Services/DomainsDelegationSignerRecordsTest.cs
@@ -212,6 +212,11 @@ namespace dnsimple_test.Services
             {
                 Assert.AreEqual(24, record.Id);
                 Assert.AreEqual(1010, record.DomainId);
+                Assert.AreEqual("8", record.Algorithm);
+                Assert.AreEqual("C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F", record.Digest);
+                Assert.AreEqual("2", record.DigestType);
+                Assert.AreEqual("44620", record.Keytag);
+                Assert.AreEqual(null, record.PublicKey);
 
                 Assert.AreEqual(expectedUrl, client.RequestSentTo());
             });

--- a/src/dnsimple-test/Services/DomainsDelegationSignerRecordsTest.cs
+++ b/src/dnsimple-test/Services/DomainsDelegationSignerRecordsTest.cs
@@ -168,29 +168,14 @@ namespace dnsimple_test.Services
             }
             catch (DnsimpleValidationException exception)
             {
-                Assert.Multiple(() =>
-                {
-                    Assert.AreEqual("can't be blank",
-                        exception.Validation["algorithm"]?.First?.ToString());
-                    Assert.AreEqual("can't be blank",
-                        exception.Validation["digest"]?.First?.ToString());
-                    Assert.AreEqual("can't be blank",
-                        exception.Validation["digest_type"]?.First?.ToString());
-                    Assert.AreEqual("can't be blank",
-                        exception.Validation["keytag"]?.First?.ToString());
-                });
+                Assert.AreEqual("can't be blank",
+                    exception.Validation["algorithm"]?.First?.ToString());
             }
         }
 
         [Test]
         [TestCase("", "digest", "digestType", "keytag")]
-        [TestCase("algorithm", "", "digestType", "keytag")]
-        [TestCase("algorithm", "digest", "", "keytag")]
-        [TestCase("algorithm", "digest", "digestType", "")]
         [TestCase(null, "digest", "digestType", "keytag")]
-        [TestCase("algorithm", null, "digestType", "keytag")]
-        [TestCase("algorithm", "digest", null, "keytag")]
-        [TestCase("algorithm", "digest", "digestType", null)]
         public void CreateDelegationSignerRecordClientSideValidation(
             string algorithm, string digest, string digestType, string keytag)
         {

--- a/src/dnsimple-test/Services/TldsTest.cs
+++ b/src/dnsimple-test/Services/TldsTest.cs
@@ -16,7 +16,7 @@ namespace dnsimple_test.Services
 
         private const string GetTldExtendedAttributesFixture =
             "getTldExtendedAttributes/success.http";
-        
+
         private const string GetTldExtendedAttributesNoAttributesFixture =
             "getTldExtendedAttributes/success-noattributes.http";
 
@@ -26,12 +26,12 @@ namespace dnsimple_test.Services
             var loader = new FixtureLoader("v2", ListTldsFixture);
             _response = new MockResponse(loader);
         }
-        
+
         [Test]
         public void TldsResponse()
         {
             var tlds = new PaginatedResponse<TldData>(_response).Data;
-            
+
             Assert.Multiple(() =>
             {
                 Assert.AreEqual("ac", tlds.First().Tld);
@@ -45,23 +45,23 @@ namespace dnsimple_test.Services
                 Assert.IsFalse(tlds.First().TransferEnabled);
             });
         }
-        
+
         [Test]
         [TestCase("https://api.sandbox.dnsimple.com/v2/tlds")]
         public void ListTlds(string expectedUrl)
         {
             var client = new MockDnsimpleClient(ListTldsFixture);
             var response = client.Tlds.ListTlds();
-            
+
             Assert.Multiple(() =>
             {
                 Assert.AreEqual(2, response.Data.Count);
                 Assert.AreEqual(1, response.Pagination.CurrentPage);
-                
+
                 Assert.AreEqual(expectedUrl, client.RequestSentTo());
             });
         }
-        
+
         [Test]
         [TestCase("https://api.sandbox.dnsimple.com/v2/tlds?sort=tld:asc&per_page=42&page=7")]
         public void ListTldsSorted(string expectedUrl)
@@ -75,10 +75,10 @@ namespace dnsimple_test.Services
                     Page = 7
                 }
             }.SortByTld(Order.asc);
-            
+
             client.Tlds.ListTlds(options);
-            
-            
+
+
             Assert.Multiple(() =>
             {
                 Assert.AreEqual(expectedUrl, client.RequestSentTo());
@@ -91,7 +91,7 @@ namespace dnsimple_test.Services
         {
             var client = new MockDnsimpleClient(GetTldFixture);
             var tld = client.Tlds.GetTld(tldName).Data;
-            
+
             Assert.Multiple(() =>
             {
                 Assert.AreEqual("com", tld.Tld);
@@ -103,7 +103,8 @@ namespace dnsimple_test.Services
                 Assert.IsTrue(tld.RegistrationEnabled);
                 Assert.IsTrue(tld.RenewalEnabled);
                 Assert.IsTrue(tld.TransferEnabled);
-                
+                Assert.AreEqual("ds", tld.DnssecInterfaceType);
+
                 Assert.AreEqual(expectedUrl, client.RequestSentTo());
             });
         }
@@ -116,20 +117,20 @@ namespace dnsimple_test.Services
             var attributes = client.Tlds.GetTldExtendedAttributes(tldName).Data;
             var attribute = attributes.First();
             var options = attribute.Options;
-            
+
             Assert.Multiple(() =>
             {
                 Assert.AreEqual(4, attributes.Count);
-                
+
                 Assert.AreEqual("uk_legal_type", attribute.Name);
                 Assert.AreEqual("Legal type of registrant contact", attribute.Description);
                 Assert.IsFalse(attribute.Required);
-                
+
                 Assert.AreEqual(17, options.Count);
                 Assert.AreEqual("UK Individual", options.First().Title);
                 Assert.AreEqual("IND", options.First().Value);
                 Assert.AreEqual("UK Individual (our default value)", options.First().Description);
-                
+
                 Assert.AreEqual(expectedUrl, client.RequestSentTo());
             });
         }

--- a/src/dnsimple-test/fixtures/v2/api/createDelegationSignerRecord/created.http
+++ b/src/dnsimple-test/fixtures/v2/api/createDelegationSignerRecord/created.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}
+{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","public_key":null,"created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}

--- a/src/dnsimple-test/fixtures/v2/api/getDelegationSignerRecord/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/getDelegationSignerRecord/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}
+{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}

--- a/src/dnsimple-test/fixtures/v2/api/getTld/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/getTld/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}}
+{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"ds"}}

--- a/src/dnsimple-test/fixtures/v2/api/listDelegationSignerRecords/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/listDelegationSignerRecords/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}
+{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/src/dnsimple-test/fixtures/v2/api/listTlds/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/listTlds/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}
+{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false,"dnssec_interface_type":"ds"},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"key"}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}

--- a/src/dnsimple/Services/DomainsDelegationSignerRecords.cs
+++ b/src/dnsimple/Services/DomainsDelegationSignerRecords.cs
@@ -92,10 +92,9 @@ namespace dnsimple.Services
         public string Algorithm { get; set; }
 
         public string Digest { get; set; }
-
         public string DigestType { get; set; }
-
         public string Keytag { get; set; }
+        public string PublicKey { get; set; }
 
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }

--- a/src/dnsimple/Services/DomainsDelegationSignerRecords.cs
+++ b/src/dnsimple/Services/DomainsDelegationSignerRecords.cs
@@ -42,12 +42,8 @@ namespace dnsimple.Services
             builder.Method(Method.POST);
             builder.AddJsonPayload(record);
 
-            if (record.Algorithm.Trim().Equals("") ||
-                record.Digest.Trim().Equals("") ||
-                record.DigestType.Trim().Equals("") ||
-                record.Keytag.Trim().Equals(""))
-                throw new ArgumentException(
-                    "Algorithm, Digest, DigestType and Keytag cannot be null or empty");
+            if (record.Algorithm.Trim().Equals(""))
+                throw new ArgumentException("Algorithm cannot be null or empty");
 
             return new SimpleResponse<DelegationSignerRecord>(Execute(builder.Request));
         }
@@ -62,7 +58,7 @@ namespace dnsimple.Services
         /// <see>https://developer.dnsimple.com/v2/domains/dnssec/#getDomainDelegationSignerRecord</see>
         public SimpleResponse<DelegationSignerRecord> GetDelegationSignerRecord(long accountId, string domainIdentifier, long recordId)
         {
-            var builder = BuildRequestForPath(DsRecordPath(accountId, domainIdentifier, recordId)); 
+            var builder = BuildRequestForPath(DsRecordPath(accountId, domainIdentifier, recordId));
 
             return new SimpleResponse<DelegationSignerRecord>(Execute(builder.Request));
         }
@@ -95,13 +91,10 @@ namespace dnsimple.Services
         [JsonProperty(Required = Required.Always)]
         public string Algorithm { get; set; }
 
-        [JsonProperty(Required = Required.Always)]
         public string Digest { get; set; }
 
-        [JsonProperty(Required = Required.Always)]
         public string DigestType { get; set; }
 
-        [JsonProperty(Required = Required.Always)]
         public string Keytag { get; set; }
 
         public DateTime CreatedAt { get; set; }

--- a/src/dnsimple/Services/Tlds.cs
+++ b/src/dnsimple/Services/Tlds.cs
@@ -98,5 +98,6 @@ namespace dnsimple.Services
         public bool? RegistrationEnabled { get; set; }
         public bool? RenewalEnabled { get; set; }
         public bool? TransferEnabled { get; set; }
+        public string DnssecInterfaceType { get; set; }
     }
 }


### PR DESCRIPTION
This PR:
* Updates the fixtures from [dnsimple-developer repo](https://github.com/dnsimple/dnsimple-developer/tree/main/fixtures/v2/api) to reflect the latest changes to our DNSSEC-related APIs.
* Adds new fields to affected structs/DTOs.
* Updates option validation on affected endpoints.
* Completes specs on `GetDelegationSignerRecord` method to be able to test the addition of `PublicKey`.