### PR TITLE
Automate release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+---
+name: release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  publish:
+    name: Publish to NuGet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rohith/publish-nuget@v2
+        with:
+          PROJECT_FILE_PATH: src/dnsimple/dnsimple.csproj
+          PACKAGE_NAME: DNSimple
+          NUGET_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,4 +15,5 @@ jobs:
         with:
           PROJECT_FILE_PATH: src/dnsimple/dnsimple.csproj
           PACKAGE_NAME: DNSimple
+          TAG_FORMAT: v*.*.*
           NUGET_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,18 +56,6 @@ The following instructions uses $VERSION as a placeholder, where $VERSION is a M
     git push origin --tags
     ```
 
-1. Create the NuGet Package
-
-    ```shell
-    dotnet pack /p:PackageVersion=$VERSION -c Release
-    ```
-
-1. Upload the package to [NuGet](https://www.nuget.org/) by using the web interface or pushing the package
-
-    ```shell
-    dotnet nuget push ./src/dnsimple/bin/Release/DNSimple.$VERSION.nupkg -k <TOKEN> -s https://api.nuget.org/v3/index.json
-    ```
-
 ## Testing
 
 Submit unit tests for your changes. You can test your changes on your machine by [running the test suite](#testing).


### PR DESCRIPTION
Adds the automated release workflow.

When a new tag is pushed the release workflow will pick it up and start the releasing of the new version.

Things that need to be done (configuration wise), which I have no access to (we need someone with admin rights on this repo for that):

- [x] add the NUGET_API_KEY to the secrets