### PR TITLE
Move test project to .NET 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       matrix:
         dotnet-version:
           - '5.0.x'
+          - '6.0.x'
     steps:
       - uses: actions/checkout@v2
       - name: Setup dotnet ${{ matrix.dotnet-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
     strategy:
       matrix:
         dotnet-version:
-          - '5.0.x'
           - '6.0.x'
     steps:
       - uses: actions/checkout@v2

--- a/src/dnsimple-test/dnsimple-test.csproj
+++ b/src/dnsimple-test/dnsimple-test.csproj
@@ -1,12 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>dnsimple_test</RootNamespace>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
   <ItemGroup>
   </ItemGroup>
 


### PR DESCRIPTION
With the upcoming .NET 5 EOL on May 08, 2022 (as per https://dotnet.microsoft.com/en-us/download/dotnet). We can get ahead and move the test project to .NET 6 already.