### PR TITLE
No longer require `contact_id` to purchase LetsEncrypt certificates

### DIFF
--- a/src/dnsimple-test/Services/CertificatesTest.cs
+++ b/src/dnsimple-test/Services/CertificatesTest.cs
@@ -50,7 +50,7 @@ namespace dnsimple_test.Services
         {
             var certificate =
                 new PaginatedResponse<Certificate>(_response).Data;
-        
+
             var expectedCSR =
                 "-----BEGIN CERTIFICATE REQUEST-----\n" +
                 "MIICYDCCAUgCAQAwGzEZMBcGA1UEAwwQd3d3Mi5kbnNpbXBsZS51czCCASIwDQYJ\n" +
@@ -73,7 +73,6 @@ namespace dnsimple_test.Services
                 Assert.AreEqual(2, certificate.Count);
                 Assert.AreEqual(101973, certificate.First().Id);
                 Assert.AreEqual(14279, certificate.First().DomainId);
-                Assert.AreEqual(11435, certificate.First().ContactId);
                 Assert.AreEqual("www2.dnsimple.us", certificate.First().CommonName);
                 Assert.AreEqual(1, certificate.First().Years);
                 Assert.AreEqual(expectedCSR, certificate.First().Csr);
@@ -171,7 +170,6 @@ namespace dnsimple_test.Services
             {
                 Assert.AreEqual(101967, certificate.Id);
                 Assert.AreEqual(289333, certificate.DomainId);
-                Assert.AreEqual(2511, certificate.ContactId);
                 Assert.AreEqual("www.bingo.pizza", certificate.CommonName);
                 Assert.AreEqual(1, certificate.Years);
                 Assert.AreEqual(expectedCertificate, certificate.Csr);
@@ -182,7 +180,7 @@ namespace dnsimple_test.Services
                 Assert.AreEqual(Convert.ToDateTime("2020-06-18T18:54:17Z"), certificate.CreatedAt);
                 Assert.AreEqual(Convert.ToDateTime("2020-06-18T19:10:14Z"), certificate.UpdatedAt);
                 Assert.AreEqual(Convert.ToDateTime("2020-09-16T18:10:13Z"), certificate.ExpiresAt);
-                
+
                 Assert.AreEqual(expectedUrl, client.RequestSentTo());
             });
         }
@@ -330,7 +328,6 @@ namespace dnsimple_test.Services
                 new MockDnsimpleClient(PurchaseLetsEncryptCertificateFixture);
             var certificateAttributes = new LetsencryptCertificateAttributes
             {
-                ContactId = 11,
                 AutoRenew = false,
                 Name = "SuperCertificate",
                 AlternateNames = new List<string>{"docs.bingo.pizza", "status.bingo.pizza"}
@@ -370,7 +367,6 @@ namespace dnsimple_test.Services
             {
                 Assert.AreEqual(101967, certificate.Id);
                 Assert.AreEqual(289333, certificate.DomainId);
-                Assert.AreEqual(2511, certificate.ContactId);
                 Assert.AreEqual("www.bingo.pizza", certificate.CommonName);
                 Assert.AreEqual(1, certificate.Years);
                 Assert.IsNull(certificate.Csr);
@@ -436,7 +432,6 @@ namespace dnsimple_test.Services
             {
                 Assert.AreEqual(101972, renewalIssued.Id);
                 Assert.AreEqual(289333, renewalIssued.DomainId);
-                Assert.AreEqual(2511, renewalIssued.ContactId);
                 Assert.AreEqual("www.bingo.pizza", renewalIssued.CommonName);
                 Assert.AreEqual(1, renewalIssued.Years);
                 Assert.IsNull(renewalIssued.Csr);

--- a/src/dnsimple/Services/Certificates.cs
+++ b/src/dnsimple/Services/Certificates.cs
@@ -75,7 +75,7 @@ namespace dnsimple.Services
         /// <see>https://developer.dnsimple.com/v2/certificates/#getCertificatePrivateKey</see>
         public SimpleResponse<CertificateBundle> GetCertificatePrivateKey(long accountId, string domainIdentifier, long certificateId)
         {
-            var builder = BuildRequestForPath(CertificatePrivateKeyPath(accountId, domainIdentifier, certificateId)); 
+            var builder = BuildRequestForPath(CertificatePrivateKeyPath(accountId, domainIdentifier, certificateId));
 
             return new SimpleResponse<CertificateBundle>(Execute(builder.Request));
         }
@@ -187,6 +187,7 @@ namespace dnsimple.Services
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     public struct LetsencryptCertificateAttributes
     {
+        [ObsoleteAttribute("ContactId is deprecated and its value is ignored and will be removed in the next major version.")]
         public long? ContactId { get; set; }
         public bool AutoRenew { get; set; }
         public string Name { get; set; }
@@ -202,6 +203,7 @@ namespace dnsimple.Services
     {
         public long Id { get; set; }
         public long DomainId { get; set; }
+        [ObsoleteAttribute("ContactId is deprecated and its value is ignored and will be removed in the next major version.")]
         public long ContactId { get; set; }
         public string CommonName { get; set; }
         public long Years { get; set; }
@@ -225,13 +227,13 @@ namespace dnsimple.Services
     {
         [JsonProperty("server")]
         public string ServerCertificate { get; set; }
-        
+
         [JsonProperty("root")]
         public string RootCertificate { get; set; }
-        
+
         [JsonProperty("chain")]
         public List<string> IntermediateCertificates { get; set; }
-        
+
         public string PrivateKey { get; set; }
     }
 }


### PR DESCRIPTION
We are flagging 2 attributes as deprecated/obsolete:
- `LetsencryptCertificateAttributes.ContactId`
- `Certificate.ContactId`

Note that `LetsencryptCertificateAttributes.ContactId` is flagged as optional/nullable so it can be ignored when purchasing the certificate already (which was wrong, but is now correct):

https://github.com/dnsimple/dnsimple-csharp/blob/5ce5453bdf3d93f554464feceeaa1056f5ec5b4a/src/dnsimple/Services/Certificates.cs#L190
