### PR TITLE
Implement getDomainRenewal and getDomainRegistration endpoints

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+dotnet-core 6.0.406

--- a/src/dnsimple-test/Services/RegistrarTest.cs
+++ b/src/dnsimple-test/Services/RegistrarTest.cs
@@ -45,6 +45,8 @@ namespace dnsimple_test.Services
 
         private const string RenewDomainFixture = "renewDomain/success.http";
 
+        private const string GetDomainRenewalFixture = "getDomainRenewal/success.http";
+
         private const string RenewDomainTooEarlyFixture =
             "renewDomain/error-tooearly.http";
 
@@ -435,6 +437,28 @@ namespace dnsimple_test.Services
             {
                 Assert.AreEqual("new", domain.State);
                 Assert.AreEqual(1, domain.Period);
+
+                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+            });
+        }
+
+        [Test]
+        [TestCase(1010, "example.com", 1,
+            "https://api.sandbox.dnsimple.com/v2/1010/registrar/domains/example.com/renewals/1")]
+        public void GetDomainRenewal(long accountId, string domainName, long domainRenewalId,
+            string expectedUrl)
+        {
+            var client = new MockDnsimpleClient(GetDomainRenewalFixture);
+            var domainRenewal = client.Registrar.GetDomainRenewal(accountId, domainName, domainRenewalId).Data;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(1, domainRenewal.Id);
+                Assert.AreEqual(999, domainRenewal.DomainId);
+                Assert.AreEqual(1, domainRenewal.Period);
+                Assert.AreEqual("renewed", domainRenewal.State);
+                Assert.AreEqual(Convert.ToDateTime("2016-12-09T19:46:45Z"), domainRenewal.CreatedAt);
+                Assert.AreEqual(Convert.ToDateTime("2016-12-12T19:46:45Z"), domainRenewal.UpdatedAt);
 
                 Assert.AreEqual(expectedUrl, client.RequestSentTo());
             });

--- a/src/dnsimple-test/Services/RegistrarTest.cs
+++ b/src/dnsimple-test/Services/RegistrarTest.cs
@@ -25,6 +25,9 @@ namespace dnsimple_test.Services
         private const string RegisterDomainFixture =
             "registerDomain/success.http";
 
+        private const string GetDomainRegistrationFixture =
+            "getDomainRegistration/success.http";
+
         private const string TransferDomainFixture =
             "transferDomain/success.http";
 
@@ -154,6 +157,32 @@ namespace dnsimple_test.Services
                 Assert.IsFalse(registeredDomain.WhoisPrivacy);
                 Assert.AreEqual(CreatedAt, registeredDomain.CreatedAt);
                 Assert.AreEqual(UpdatedAt, registeredDomain.UpdatedAt);
+
+                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+            });
+        }
+
+        [Test]
+        [TestCase(1010, "ruby.codes", 361,
+            "https://api.sandbox.dnsimple.com/v2/1010/registrar/domains/ruby.codes/registrations/361")]
+        public void GetDomainRegistration(long accountId, string domainName,
+            long domainRegistrationId, string expectedUrl)
+        {
+            var client = new MockDnsimpleClient(GetDomainRegistrationFixture);
+            var domain = client.Registrar.GetDomainRegistration(accountId,
+                domainName, domainRegistrationId).Data;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(361, domain.Id);
+                Assert.AreEqual(104040, domain.DomainId);
+                Assert.AreEqual(2715, domain.RegistrantId);
+                Assert.AreEqual(1, domain.Period);
+                Assert.AreEqual("registering", domain.State);
+                Assert.IsFalse(domain.AutoRenew);
+                Assert.IsFalse(domain.WhoisPrivacy);
+                Assert.AreEqual(CreatedAt, domain.CreatedAt);
+                Assert.AreEqual(UpdatedAt, domain.UpdatedAt);
 
                 Assert.AreEqual(expectedUrl, client.RequestSentTo());
             });

--- a/src/dnsimple-test/dnsimple-test.csproj
+++ b/src/dnsimple-test/dnsimple-test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -366,6 +366,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="fixtures\v2\api\renewDomain\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\getDomainRenewal\success.http">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="fixtures\v2\api\renewWhoisPrivacy\success.http">

--- a/src/dnsimple-test/dnsimple-test.csproj
+++ b/src/dnsimple-test/dnsimple-test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -351,6 +351,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="fixtures\v2\api\registerDomain\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\getDomainRegistration\success.http">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="fixtures\v2\api\rejectPush\success.http">

--- a/src/dnsimple-test/fixtures/v2/api/getDomainRegistration/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/getDomainRegistration/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Fri, 05 Jun 2020 18:23:53 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2392
+X-RateLimit-Reset: 1591384034
+ETag: W/"80c5827934c13b1ca87a587d96e7d1e8"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 9f4959ee-06a9-488c-906e-27a570cafbbf
+X-Runtime: 0.078429
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":361,"domain_id":104040,"registrant_id":2715,"period":1,"state":"registering","auto_renew":false,"whois_privacy":false,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}

--- a/src/dnsimple-test/fixtures/v2/api/getDomainRenewal/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/getDomainRenewal/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Fri, 09 Dec 2016 19:46:57 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1481315245
+ETag: W/"179d85ea8a26a3d5dc76e42de2d7918e"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: ba6f2707-5df0-4ffa-b91b-51d4460bab8e
+X-Runtime: 13.571302
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"domain_id":999,"period":1,"state":"renewed","created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-12T19:46:45Z"}}

--- a/src/dnsimple/Services/Paths.cs
+++ b/src/dnsimple/Services/Paths.cs
@@ -138,7 +138,7 @@ namespace dnsimple.Services
                 $"{RegistrarPath(accountId, domainName)}/authorize_transfer_out";
         }
 
-        public static string DomainRenewalPath(long accountId, string domainName)
+        public static string RenewDomainPath(long accountId, string domainName)
         {
             return $"{RegistrarPath(accountId, domainName)}/renewals";
         }

--- a/src/dnsimple/Services/Paths.cs
+++ b/src/dnsimple/Services/Paths.cs
@@ -153,6 +153,11 @@ namespace dnsimple.Services
             return $"{RegistrarPath(accountId, domainName)}/transfers/{domainTransferId}";
         }
 
+        public static string DomainRegistrationPath(long accountId, string domainName, long domainRegistrationId)
+        {
+            return $"{RegistrarPath(accountId, domainName)}/registrations/{domainRegistrationId}";
+        }
+
         public static string RegisterDomainPath(long accountId, string domainName)
         {
             return $"{RegistrarPath(accountId, domainName)}/registrations";

--- a/src/dnsimple/Services/Paths.cs
+++ b/src/dnsimple/Services/Paths.cs
@@ -143,6 +143,11 @@ namespace dnsimple.Services
             return $"{RegistrarPath(accountId, domainName)}/renewals";
         }
 
+        public static string DomainRenewalPath(long accountId, string domainName, long domainRenewalId)
+        {
+            return $"{RegistrarPath(accountId, domainName)}/renewals/{domainRenewalId}";
+        }
+
         public static string TransferDomainPath(long accountId, string domainName)
         {
             return $"{RegistrarPath(accountId, domainName)}/transfers";

--- a/src/dnsimple/Services/Paths.cs
+++ b/src/dnsimple/Services/Paths.cs
@@ -153,8 +153,7 @@ namespace dnsimple.Services
             return $"{RegistrarPath(accountId, domainName)}/transfers/{domainTransferId}";
         }
 
-        public static string DomainRegistrationPath(long accountId,
-            string domainName)
+        public static string RegisterDomainPath(long accountId, string domainName)
         {
             return $"{RegistrarPath(accountId, domainName)}/registrations";
         }

--- a/src/dnsimple/Services/Registrar.cs
+++ b/src/dnsimple/Services/Registrar.cs
@@ -127,7 +127,7 @@ namespace dnsimple.Services
         /// <see>https://developer.dnsimple.com/v2/registrar/#renewDomain</see>
         public SimpleResponse<DomainRenewal> RenewDomain(long accountId, string domainName, DomainRenewalInput input)
         {
-            var builder = BuildRequestForPath(DomainRenewalPath(accountId, domainName));
+            var builder = BuildRequestForPath(RenewDomainPath(accountId, domainName));
             builder.Method(Method.POST);
             builder.AddJsonPayload(input);
 

--- a/src/dnsimple/Services/Registrar.cs
+++ b/src/dnsimple/Services/Registrar.cs
@@ -64,6 +64,22 @@ namespace dnsimple.Services
         }
 
         /// <summary>
+        /// Retrieve the details of an existing domain registration.
+        /// </summary>
+        /// <param name="accountId">The account ID</param>
+        /// <param name="domainName">The domain name</param>
+        /// <param name="domainRegistrationId">The domain registration Id</param>
+        /// <returns>The domain registration</returns>
+        /// <see cref="DomainRegistration"/>
+        /// <see>https://developer.dnsimple.com/v2/registrar/#getDomainRegistration</see>
+        public SimpleResponse<DomainRegistration> GetDomainRegistration(long accountId, string domainName, long domainRegistrationId)
+        {
+            var builder = BuildRequestForPath(DomainRegistrationPath(accountId, domainName, domainRegistrationId));
+
+            return new SimpleResponse<DomainRegistration>(Execute(builder.Request));
+        }
+
+        /// <summary>
         /// Transfer a domain name from another registrar.
         /// </summary>
         /// <param name="accountId">The account ID</param>

--- a/src/dnsimple/Services/Registrar.cs
+++ b/src/dnsimple/Services/Registrar.cs
@@ -151,6 +151,22 @@ namespace dnsimple.Services
         }
 
         /// <summary>
+        /// Retrieves the details of an existing domain renewal.
+        /// </summary>
+        /// <param name="accountId">The account ID</param>
+        /// <param name="domainName">The domain name</param>
+        /// <param name="domainRenewalId">The domain renewal Id</param>
+        /// <returns>The domain renewal</returns>
+        /// <see cref="DomainRenewal"/>
+        /// <see>https://developer.dnsimple.com/v2/registrar/#getDomainRenewal</see>
+        public SimpleResponse<DomainRenewal> GetDomainRenewal(long accountId, string domainName, long domainRenewalId)
+        {
+            var builder = BuildRequestForPath(DomainRenewalPath(accountId, domainName, domainRenewalId));
+
+            return new SimpleResponse<DomainRenewal>(Execute(builder.Request));
+        }
+
+        /// <summary>
         /// Prepares a domain for transferring out.
         /// </summary>
         /// <param name="accountId">The account ID</param>

--- a/src/dnsimple/Services/Registrar.cs
+++ b/src/dnsimple/Services/Registrar.cs
@@ -56,7 +56,7 @@ namespace dnsimple.Services
         /// <see>https://developer.dnsimple.com/v2/registrar/#registerDomain</see>
         public SimpleResponse<DomainRegistration> RegisterDomain(long accountId, string domainName, DomainRegistrationInput domain)
         {
-            var builder = BuildRequestForPath(DomainRegistrationPath(accountId, domainName));
+            var builder = BuildRequestForPath(RegisterDomainPath(accountId, domainName));
             builder.Method(Method.POST);
             builder.AddJsonPayload(domain);
 


### PR DESCRIPTION
Recently we introduced two new endpoints (https://github.com/dnsimple/dnsimple-developer/pull/457) in our API for users to retrieve their domain registration and renewal service objects.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1674