### PR TITLE
Add support to activate and deactivate DNS services for a zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+## 0.15.0 (Unreleased)
+
+FEATURES:
+
+- NEW: Added `Dnsimple.Zones.ActivateDns` to activate DNS services (resolution) for a zone. (dnsimple/dnsimple-csharp#128)
+- NEW: Added `Dnsimple.Zones.DeactivateDns` to deactivate DNS services (resolution) for a zone. (dnsimple/dnsimple-csharp#128)
+
+IMPROVEMENTS:
+
+- `EmailForward` `From` is deprecated. Please use `AliasName` instead for creating email forwards. (dnsimple/dnsimple-csharp#128)
+- `EmailForward` `To` is deprecated. Please use `DestinationEmail` instead for creating email forwards. (dnsimple/dnsimple-csharp#128)
+
 ## 0.14.0
 
 - NEW: Adds getDomainRenewal and getDomainRegistration API endpoints (dnsimple/dnsimple-csharp#113)

--- a/src/dnsimple-test/Services/DomainsEmailForwardsTest.cs
+++ b/src/dnsimple-test/Services/DomainsEmailForwardsTest.cs
@@ -117,8 +117,8 @@ namespace dnsimple_test.Services
             var client = new MockDnsimpleClient(CreateEmailForwardFixture);
             var record = new EmailForward
             {
-                From = "example@dnsimple.xyz",
-                To = "example@example.com"
+                AliasName = "example@dnsimple.xyz",
+                DestinationEmail = "example@example.com"
             };
 
             var created =
@@ -129,6 +129,10 @@ namespace dnsimple_test.Services
             {
                 Assert.AreEqual(41872, created.Data.Id);
                 Assert.AreEqual(235146, created.Data.DomainId);
+                Assert.AreEqual(record.AliasName, created.Data.AliasName);
+                Assert.AreEqual(record.DestinationEmail, created.Data.DestinationEmail);
+
+                // Deprecated
                 Assert.AreEqual(record.From, created.Data.From);
                 Assert.AreEqual(record.To, created.Data.To);
 
@@ -146,8 +150,8 @@ namespace dnsimple_test.Services
             var client = new MockDnsimpleClient(CreateEmailForwardFixture);
             var record = new EmailForward
             {
-                From = from,
-                To = to
+                AliasName = from,
+                DestinationEmail = to
             };
 
             Assert.Throws(Is.InstanceOf<Exception>(),

--- a/src/dnsimple-test/dnsimple-test.csproj
+++ b/src/dnsimple-test/dnsimple-test.csproj
@@ -38,6 +38,12 @@
     <Content Include="fixtures\v2\api\applyTemplate\success.http">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="fixtures\v2\api\activateZoneService\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\deactivateZoneService\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="fixtures\v2\api\authorizeDomainTransferOut\success.http">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/dnsimple-test/fixtures/v2/api/activateZoneService/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/activateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:23 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1691471963
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"fe6afd982459be33146933235343d51d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8e8ac535-9f46-4304-8440-8c68c30427c3
+X-Runtime: 0.176579
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/src/dnsimple-test/fixtures/v2/api/deactivateZoneService/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/deactivateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:52 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1691471962
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"5f30a37d01b99bb9e620ef1bbce9a014"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d2f7bba4-4c81-4818-81d2-c9bbe95f104e
+X-Runtime: 0.133278
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/src/dnsimple/Services/DomainsEmailForwards.cs
+++ b/src/dnsimple/Services/DomainsEmailForwards.cs
@@ -45,9 +45,9 @@ namespace dnsimple.Services
             builder.Method(Method.POST);
             builder.AddJsonPayload(record);
 
-            if(record.To.Trim().Equals("") || record.From.Trim().Equals(""))
-                throw new ArgumentException("From or To cannot be blank");
-            
+            if (record.To.Trim().Equals("") || record.From.Trim().Equals(""))
+                throw new ArgumentException("AliasName or DestinationEmail cannot be blank");
+
             return new SimpleResponse<EmailForward>(Execute(builder.Request));
         }
 
@@ -61,8 +61,8 @@ namespace dnsimple.Services
         /// <see>https://developer.dnsimple.com/v2/domains/email-forwards/#getEmailForward</see>
         public SimpleResponse<EmailForward> GetEmailForward(long accountId, string domainIdentifier, int emailForwardId)
         {
-            var builder = BuildRequestForPath(EmailForwardPath(accountId, domainIdentifier, emailForwardId)); 
-            
+            var builder = BuildRequestForPath(EmailForwardPath(accountId, domainIdentifier, emailForwardId));
+
             return new SimpleResponse<EmailForward>(Execute(builder.Request));
         }
 
@@ -91,11 +91,39 @@ namespace dnsimple.Services
         public long Id { get; set; }
         public long DomainId { get; set; }
 
-        [JsonProperty(Required = Required.Always)]
-        public string From { get; set; }
+        public string AliasName { get; set; }
 
-        [JsonProperty(Required = Required.Always)]
-        public string To { get; set; }
+        public string From
+        {
+            get
+            {
+                // If To is accessed, return the value from AliasName
+                return AliasName;
+            }
+            [Obsolete("From is deprecated. Please use AliasName instead.")]
+            set
+            {
+                // If To is set, set the value to AliasName
+                AliasName = value;
+            }
+        }
+
+        public string DestinationEmail { get; set; }
+
+        public string To
+        {
+            get
+            {
+                // If From is accessed, return the value from DestinationEmail
+                return DestinationEmail;
+            }
+            [Obsolete("To is deprecated. Please use DestinationEmail instead.")]
+            set
+            {
+                // If From is set, set the value to DestinationEmail
+                DestinationEmail = value;
+            }
+        }
 
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }

--- a/src/dnsimple/Services/Paths.cs
+++ b/src/dnsimple/Services/Paths.cs
@@ -328,6 +328,11 @@ namespace dnsimple.Services
             return $"{ZonePath(accountId, zoneName)}/file";
         }
 
+        public static string ZoneResolutionPath(long accountId, string zoneName)
+        {
+            return $"{ZonePath(accountId, zoneName)}/activation";
+        }
+
         public static string ZonePath(long accountId, string zoneName)
         {
             return $"{ZonesPath(accountId)}/{zoneName}";

--- a/src/dnsimple/Services/Zones.cs
+++ b/src/dnsimple/Services/Zones.cs
@@ -2,6 +2,7 @@ using System;
 using dnsimple.Services.ListOptions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using RestSharp;
 using static dnsimple.Services.Paths;
 
 namespace dnsimple.Services
@@ -45,7 +46,7 @@ namespace dnsimple.Services
         public SimpleResponse<Zone> GetZone(long accountId, string zoneName)
         {
             var builder = BuildRequestForPath(ZonePath(accountId, zoneName));
-                
+
             return new SimpleResponse<Zone>(Execute(builder.Request));
         }
 
@@ -76,6 +77,36 @@ namespace dnsimple.Services
             var builder = BuildRequestForPath(ZoneDistributionPath(accountId, zoneName));
 
             return new SimpleResponse<ZoneDistribution>(Execute(builder.Request));
+        }
+
+        /// <summary>
+        /// Activate DNS resolution for the zone in the account.
+        /// </summary>
+        /// <param name="accountId">The account ID</param>
+        /// <param name="zoneName">The zone name</param>
+        /// <returns>A <c>ZoneResponse</c> containing the zone.</returns>
+        /// <see>https://developer.dnsimple.com/v2/zones/#activateZoneService</see>
+        public SimpleResponse<Zone> ActivateDns(long accountId, string zoneName)
+        {
+            var builder = BuildRequestForPath(ZoneResolutionPath(accountId, zoneName));
+            builder.Method(Method.PUT);
+
+            return new SimpleResponse<Zone>(Execute(builder.Request));
+        }
+
+        /// <summary>
+        /// Deactivate DNS resolution for the zone in the account.
+        /// </summary>
+        /// <param name="accountId">The account ID</param>
+        /// <param name="zoneName">The zone name</param>
+        /// <returns>A <c>ZoneResponse</c> containing the zone.</returns>
+        /// <see>https://developer.dnsimple.com/v2/zones/#deactivateZoneService</see>
+        public SimpleResponse<Zone> DeactivateDns(long accountId, string zoneName)
+        {
+            var builder = BuildRequestForPath(ZoneResolutionPath(accountId, zoneName));
+            builder.Method(Method.DELETE);
+
+            return new SimpleResponse<Zone>(Execute(builder.Request));
         }
     }
 


### PR DESCRIPTION
This PR implements https://github.com/dnsimple/dnsimple-developer/pull/502 which allows for the management of DNS resolution for a particular zone.

This PR also updates the `EmailForward` with new attributes replacing `To` and `From` for email forward resource creation. See the changelog for more information.


Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/3
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/2