### PR TITLE
Add missing attributes to the Zone API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+- NEW: Added `Secondary`, `LastTransferredAt`, `Active` to `Zone` (dnsimple/dnsimple-csharp)
+
 ## 0.15.0
 
 FEATURES:

--- a/src/dnsimple-test/Services/ZonesTest.cs
+++ b/src/dnsimple-test/Services/ZonesTest.cs
@@ -56,6 +56,9 @@ namespace dnsimple_test.Services
                 Assert.AreEqual(1010, zones.First().AccountId);
                 Assert.AreEqual("example-alpha.com", zones.First().Name);
                 Assert.IsFalse(zones.First().Reverse);
+                Assert.IsFalse(zones.First().Secondary);
+                Assert.Null(zones.First().LastTransferredAt);
+                Assert.IsTrue(zones.First().Active);
                 Assert.AreEqual(CreatedAt, zones.First().CreatedAt);
                 Assert.AreEqual(UpdatedAt, zones.First().UpdatedAt);
             });
@@ -126,6 +129,9 @@ namespace dnsimple_test.Services
                 Assert.AreEqual(accountId, zone.AccountId);
                 Assert.AreEqual(zoneName, zone.Name);
                 Assert.False(zone.Reverse);
+                Assert.IsFalse(zone.Secondary);
+                Assert.Null(zone.LastTransferredAt);
+                Assert.IsTrue(zone.Active);
                 Assert.AreEqual(CreatedAt, zone.CreatedAt);
                 Assert.AreEqual(UpdatedAt, zone.UpdatedAt);
 

--- a/src/dnsimple-test/fixtures/v2/api/getZone/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/getZone/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 93182033-a215-484e-a107-5235fa48001c
 X-Runtime: 0.177942
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}
+{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/src/dnsimple-test/fixtures/v2/api/listZones/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/listZones/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 01be9fa5-3a00-4d51-a927-f17587cb67ec
 X-Runtime: 0.037083
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}

--- a/src/dnsimple/Services/Zones.cs
+++ b/src/dnsimple/Services/Zones.cs
@@ -121,6 +121,9 @@ namespace dnsimple.Services
         public long AccountId { get; set; }
         public string Name { get; set; }
         public bool Reverse { get; set; }
+        public bool Secondary { get; set; }
+        public Nullable<DateTime> LastTransferredAt { get; set; }
+        public bool Active { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
     }


### PR DESCRIPTION
This PR adds [missing attributes](https://github.com/dnsimple/dnsimple-developer/pull/542) of the Zone response:

- `Secondary`, `LastTransferredAt`, `Active` to Zone struct

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/17