### PR TITLE
Domain contact management API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+## 0.17.0 (Unreleased)
+
+FEATURES:
+
+- NEW: Added `Dnsimple.Registrar.CheckRegistrantChange` to retrieves the requirements of a registrant change. (#140)
+- NEW: Added `Dnsimple.Registrar.GetRegistrantChange` to retrieves the details of an existing registrant change. (#140)
+- NEW: Added `Dnsimple.Registrar.CreateRegistrantChange` to start registrant change. (#140)
+- NEW: Added `Dnsimple.Registrar.ListRegistrantChanges` to lists the registrant changes for a domain. (#140)
+- NEW: Added `Dnsimple.Registrar.DeleteRegistrantChange` to cancel an ongoing registrant change from the account. (#140)
+
 ## 0.16.0
 
 FEATURES:

--- a/src/dnsimple-test/FixtureLoader.cs
+++ b/src/dnsimple-test/FixtureLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -25,7 +26,7 @@ namespace dnsimple_test
         private string JsonPartFrom(string fixture)
         {
             Fixture = fixture;
-            LoadFixture(); 
+            LoadFixture();
             var lastLine = GetLines(true).Last();
             return IsValidJson(lastLine) ? lastLine : "";
         }
@@ -54,7 +55,7 @@ namespace dnsimple_test
             return LoadFixture().Split(new[] { "\r\n", "\r", "\n" },
                 removeEmptyLines ? StringSplitOptions.RemoveEmptyEntries : StringSplitOptions.None);
         }
-        
+
 
         private string LoadFixture()
         {
@@ -70,16 +71,22 @@ namespace dnsimple_test
 
             foreach (var line in GetLines())
             {
-                if(String.IsNullOrEmpty(line))
+                if (String.IsNullOrEmpty(line))
                     break;
                 if (line.Contains(':'))
                 {
                     var header = line.Split(':');
-                    headers.Add(new Parameter(header[0], header[1], ParameterType.HttpHeader)); 
+                    headers.Add(new Parameter(header[0], header[1], ParameterType.HttpHeader));
                 }
             }
 
             return headers;
+        }
+
+        public HttpStatusCode ExtractStatusCode()
+        {
+            return (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode),
+                GetLines().First().Split(' ')[1]);
         }
     }
 }

--- a/src/dnsimple-test/MockDnsimpleClient.cs
+++ b/src/dnsimple-test/MockDnsimpleClient.cs
@@ -52,12 +52,12 @@ namespace dnsimple_test
             Webhooks = new WebhooksService(this);
             Zones = new ZonesService(this);
         }
-        
+
         public void StatusCode(HttpStatusCode statusCode)
         {
             ((MockHttpService)Http).StatusCode = statusCode;
         }
-        
+
         public void ChangeBaseUrlTo(string baseUrl)
         {
             // Not needed at the moment, but having to implement...
@@ -80,17 +80,17 @@ namespace dnsimple_test
 
         public string RequestSentTo()
         {
-            return ((MockHttpService) Http).RequestUrlSent.UrlDecode();
+            return ((MockHttpService)Http).RequestUrlSent.UrlDecode();
         }
 
         public Method HttpMethodUsed()
         {
-            return ((MockHttpService) Http).MethodSent;
+            return ((MockHttpService)Http).MethodSent;
         }
 
         public string PayloadSent()
         {
-            return ((MockHttpService) Http).PayloadSent;
+            return ((MockHttpService)Http).PayloadSent;
         }
     }
 
@@ -98,7 +98,7 @@ namespace dnsimple_test
     {
         private readonly FixtureLoader _fixtureLoader;
         private readonly string _baseUrl;
-        
+
         public HttpStatusCode StatusCode { get; set; }
         public string RequestUrlSent { get; private set; }
         public Method MethodSent { get; private set; }
@@ -122,7 +122,7 @@ namespace dnsimple_test
             MethodSent = request.Method;
             try
             {
-                PayloadSent = (string) request.Parameters.Find(x =>
+                PayloadSent = (string)request.Parameters.Find(x =>
                     x.ContentType.Equals("application/json")).Value;
             }
             catch (Exception)
@@ -156,10 +156,11 @@ namespace dnsimple_test
     {
         public MockResponse(FixtureLoader loader)
         {
+            StatusCode = loader.ExtractStatusCode();
             Content = loader.ExtractJsonPayload();
             Headers = loader.ExtractHeaders();
         }
-        
+
         public void SetHeaders(List<Parameter> headers)
         {
             Headers = headers;

--- a/src/dnsimple-test/Services/RegistrarTest.cs
+++ b/src/dnsimple-test/Services/RegistrarTest.cs
@@ -164,12 +164,12 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(101, check.ContactId);
-                Assert.AreEqual(101, check.DomainId);
-                Assert.IsInstanceOf<List<TldExtendedAttribute>>(check.ExtendedAttributes);
-                Assert.AreEqual(true, check.RegistryOwnerChange);
+                Assert.That(check.ContactId, Is.EqualTo(101));
+                Assert.That(check.DomainId, Is.EqualTo(101));
+                Assert.That(check.ExtendedAttributes, Is.InstanceOf<List<TldExtendedAttribute>>());
+                Assert.That(check.RegistryOwnerChange, Is.EqualTo(true));
 
-                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+                Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
 
@@ -179,23 +179,23 @@ namespace dnsimple_test.Services
         public void GetRegistrantChange(long accountId, long registrantChangeId, string expectedUrl)
         {
             var client = new MockDnsimpleClient(GetRegistrantChangeFixture);
-            var check = client.Registrar.GetRegistrantChange(accountId, registrantChangeId)
+            var registrantChange = client.Registrar.GetRegistrantChange(accountId, registrantChangeId)
                 .Data;
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(101, check.Id);
-                Assert.AreEqual(101, check.AccountId);
-                Assert.AreEqual(101, check.ContactId);
-                Assert.AreEqual(101, check.DomainId);
-                Assert.AreEqual("new", check.State);
-                Assert.IsInstanceOf<Dictionary<string, string>>(check.ExtendedAttributes);
-                Assert.AreEqual(true, check.RegistryOwnerChange);
-                Assert.AreEqual(null, check.IrtLockLiftedBy);
-                Assert.AreEqual(CreatedAt, check.CreatedAt);
-                Assert.AreEqual(UpdatedAt, check.UpdatedAt);
+                Assert.That(registrantChange.Id, Is.EqualTo(101));
+                Assert.That(registrantChange.AccountId, Is.EqualTo(101));
+                Assert.That(registrantChange.ContactId, Is.EqualTo(101));
+                Assert.That(registrantChange.DomainId, Is.EqualTo(101));
+                Assert.That(registrantChange.State, Is.EqualTo("new"));
+                Assert.That(registrantChange.ExtendedAttributes, Is.InstanceOf<Dictionary<string, string>>());
+                Assert.That(registrantChange.RegistryOwnerChange, Is.EqualTo(true));
+                Assert.That(registrantChange.IrtLockLiftedBy, Is.EqualTo(null));
+                Assert.That(registrantChange.CreatedAt, Is.EqualTo(CreatedAt));
+                Assert.That(registrantChange.UpdatedAt, Is.EqualTo(UpdatedAt));
 
-                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+                Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
 
@@ -220,18 +220,18 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(101, check.Id);
-                Assert.AreEqual(101, check.AccountId);
-                Assert.AreEqual(101, check.ContactId);
-                Assert.AreEqual(101, check.DomainId);
-                Assert.AreEqual("new", check.State);
-                Assert.IsInstanceOf<Dictionary<string, string>>(check.ExtendedAttributes);
-                Assert.AreEqual(true, check.RegistryOwnerChange);
-                Assert.AreEqual(null, check.IrtLockLiftedBy);
-                Assert.AreEqual(CreatedAt, check.CreatedAt);
-                Assert.AreEqual(UpdatedAt, check.UpdatedAt);
+                Assert.That(check.Id, Is.EqualTo(101));
+                Assert.That(check.AccountId, Is.EqualTo(101));
+                Assert.That(check.ContactId, Is.EqualTo(101));
+                Assert.That(check.DomainId, Is.EqualTo(101));
+                Assert.That(check.State, Is.EqualTo("new"));
+                Assert.That(check.ExtendedAttributes, Is.InstanceOf<Dictionary<string, string>>());
+                Assert.That(check.RegistryOwnerChange, Is.EqualTo(true));
+                Assert.That(check.IrtLockLiftedBy, Is.EqualTo(null));
+                Assert.That(check.CreatedAt, Is.EqualTo(CreatedAt));
+                Assert.That(check.UpdatedAt, Is.EqualTo(UpdatedAt));
 
-                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+                Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
 
@@ -248,16 +248,16 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(101, registrantChange.Id);
-                Assert.AreEqual(101, registrantChange.AccountId);
-                Assert.AreEqual(101, registrantChange.ContactId);
-                Assert.AreEqual(101, registrantChange.DomainId);
-                Assert.AreEqual("new", registrantChange.State);
-                Assert.IsInstanceOf<Dictionary<string, string>>(registrantChange.ExtendedAttributes);
-                Assert.AreEqual(true, registrantChange.RegistryOwnerChange);
-                Assert.AreEqual(null, registrantChange.IrtLockLiftedBy);
+                Assert.That(registrantChange.Id, Is.EqualTo(101));
+                Assert.That(registrantChange.AccountId, Is.EqualTo(101));
+                Assert.That(registrantChange.ContactId, Is.EqualTo(101));
+                Assert.That(registrantChange.DomainId, Is.EqualTo(101));
+                Assert.That(registrantChange.State, Is.EqualTo("new"));
+                Assert.That(registrantChange.ExtendedAttributes, Is.InstanceOf<Dictionary<string, string>>());
+                Assert.That(registrantChange.RegistryOwnerChange, Is.EqualTo(true));
+                Assert.That(registrantChange.IrtLockLiftedBy, Is.EqualTo(null));
 
-                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+                Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
 
@@ -279,7 +279,7 @@ namespace dnsimple_test.Services
 
             client.Registrar.ListRegistrantChanges(accountId, options);
 
-            Assert.AreEqual(expectedUrl, client.RequestSentTo());
+            Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
         }
 
 
@@ -294,10 +294,10 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(true, response.IsEmpty);
+                Assert.That(response.IsEmpty, Is.EqualTo(true));
                 // data is an empty RegistrantChange object
-                Assert.AreEqual(0, data.Id);
-                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+                Assert.That(data.Id, Is.EqualTo(0));
+                Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
 
@@ -313,17 +313,17 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(false, response.IsEmpty);
-                Assert.AreEqual(101, registrantChange.Id);
-                Assert.AreEqual(101, registrantChange.AccountId);
-                Assert.AreEqual(101, registrantChange.ContactId);
-                Assert.AreEqual(101, registrantChange.DomainId);
-                Assert.AreEqual("cancelling", registrantChange.State);
+                Assert.That(response.IsEmpty, Is.EqualTo(false));
+                Assert.That(registrantChange.Id, Is.EqualTo(101));
+                Assert.That(registrantChange.AccountId, Is.EqualTo(101));
+                Assert.That(registrantChange.ContactId, Is.EqualTo(101));
+                Assert.That(registrantChange.DomainId, Is.EqualTo(101));
+                Assert.That(registrantChange.State, Is.EqualTo("cancelling"));
                 Assert.IsInstanceOf<Dictionary<string, string>>(registrantChange.ExtendedAttributes);
-                Assert.AreEqual(true, registrantChange.RegistryOwnerChange);
-                Assert.AreEqual(null, registrantChange.IrtLockLiftedBy);
+                Assert.That(registrantChange.RegistryOwnerChange, Is.EqualTo(true));
+                Assert.That(registrantChange.IrtLockLiftedBy, Is.EqualTo(null));
 
-                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+                Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
 

--- a/src/dnsimple-test/Services/RegistrarTest.cs
+++ b/src/dnsimple-test/Services/RegistrarTest.cs
@@ -319,7 +319,7 @@ namespace dnsimple_test.Services
                 Assert.That(registrantChange.ContactId, Is.EqualTo(101));
                 Assert.That(registrantChange.DomainId, Is.EqualTo(101));
                 Assert.That(registrantChange.State, Is.EqualTo("cancelling"));
-                Assert.IsInstanceOf<Dictionary<string, string>>(registrantChange.ExtendedAttributes);
+                Assert.That(registrantChange.ExtendedAttributes, Is.InstanceOf<Dictionary<string, string>>());
                 Assert.That(registrantChange.RegistryOwnerChange, Is.EqualTo(true));
                 Assert.That(registrantChange.IrtLockLiftedBy, Is.EqualTo(null));
 

--- a/src/dnsimple-test/Services/RegistrarTest.cs
+++ b/src/dnsimple-test/Services/RegistrarTest.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using dnsimple;
+using dnsimple.Services.ListOptions;
 using dnsimple.Services;
 using NUnit.Framework;
 
@@ -52,6 +54,24 @@ namespace dnsimple_test.Services
 
         private const string AuthorizeTransferOutFixture =
             "authorizeDomainTransferOut/success.http";
+
+        private const string CheckRegistrantChangeFixture =
+            "checkRegistrantChange/success.http";
+
+        private const string GetRegistrantChangeFixture =
+            "getRegistrantChange/success.http";
+
+        private const string ListRegistrantChangeFixture =
+            "listRegistrantChanges/success.http";
+
+        private const string CreateRegistrantChangeFixture =
+            "createRegistrantChange/success.http";
+
+        private const string DeleteRegistrantChangeFixture =
+            "deleteRegistrantChange/success.http";
+
+        private const string DeleteRegistrantChangeAsyncFixture =
+            "deleteRegistrantChange/success_async.http";
 
         private DateTime CreatedAt { get; } = DateTime.ParseExact(
             "2016-12-09T19:35:31Z", "yyyy-MM-ddTHH:mm:ssZ",
@@ -128,6 +148,184 @@ namespace dnsimple_test.Services
             });
         }
 
+        [Test]
+        [TestCase(1010, "example.com",
+            "https://api.sandbox.dnsimple.com/v2/1010/registrar/registrant_changes/check")]
+        public void CheckRegistrantChange(long accountId, string domainId, string expectedUrl)
+        {
+            var client = new MockDnsimpleClient(CheckRegistrantChangeFixture);
+            var checkInput = new CheckRegistrantChangeInput
+            {
+                DomainId = domainId,
+                ContactId = 101
+            };
+            var check = client.Registrar.CheckRegistrantChange(accountId, checkInput)
+                .Data;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(101, check.ContactId);
+                Assert.AreEqual(101, check.DomainId);
+                Assert.IsInstanceOf<List<TldExtendedAttribute>>(check.ExtendedAttributes);
+                Assert.AreEqual(true, check.RegistryOwnerChange);
+
+                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+            });
+        }
+
+        [Test]
+        [TestCase(1010, 101,
+        "https://api.sandbox.dnsimple.com/v2/1010/registrar/registrant_changes/101")]
+        public void GetRegistrantChange(long accountId, long registrantChangeId, string expectedUrl)
+        {
+            var client = new MockDnsimpleClient(GetRegistrantChangeFixture);
+            var check = client.Registrar.GetRegistrantChange(accountId, registrantChangeId)
+                .Data;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(101, check.Id);
+                Assert.AreEqual(101, check.AccountId);
+                Assert.AreEqual(101, check.ContactId);
+                Assert.AreEqual(101, check.DomainId);
+                Assert.AreEqual("new", check.State);
+                Assert.IsInstanceOf<Dictionary<string, string>>(check.ExtendedAttributes);
+                Assert.AreEqual(true, check.RegistryOwnerChange);
+                Assert.AreEqual(null, check.IrtLockLiftedBy);
+                Assert.AreEqual(CreatedAt, check.CreatedAt);
+                Assert.AreEqual(UpdatedAt, check.UpdatedAt);
+
+                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+            });
+        }
+
+
+        [Test]
+        [TestCase(1010, "example.com",
+        "https://api.sandbox.dnsimple.com/v2/1010/registrar/registrant_changes")]
+        public void CreateRegistrantChange(long accountId, object domainId, string expectedUrl)
+        {
+            var client = new MockDnsimpleClient(CreateRegistrantChangeFixture);
+            var createInput = new CreateRegistrantChangeInput
+            {
+                DomainId = domainId,
+                ContactId = 101,
+                ExtendedAttributes = new Dictionary<string, string>
+                {
+                    { "x-foo", "bar" }
+                }
+            };
+            var check = client.Registrar.CreateRegistrantChange(accountId, createInput)
+                .Data;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(101, check.Id);
+                Assert.AreEqual(101, check.AccountId);
+                Assert.AreEqual(101, check.ContactId);
+                Assert.AreEqual(101, check.DomainId);
+                Assert.AreEqual("new", check.State);
+                Assert.IsInstanceOf<Dictionary<string, string>>(check.ExtendedAttributes);
+                Assert.AreEqual(true, check.RegistryOwnerChange);
+                Assert.AreEqual(null, check.IrtLockLiftedBy);
+                Assert.AreEqual(CreatedAt, check.CreatedAt);
+                Assert.AreEqual(UpdatedAt, check.UpdatedAt);
+
+                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+            });
+        }
+
+        [Test]
+        [TestCase(1010,
+        "https://api.sandbox.dnsimple.com/v2/1010/registrar/registrant_changes")]
+        public void ListRegistrantChange(long accountId, string expectedUrl)
+        {
+            var client = new MockDnsimpleClient(ListRegistrantChangeFixture);
+            var registrantChanges = client.Registrar.ListRegistrantChanges(accountId)
+                .Data;
+
+            var registrantChange = registrantChanges.First();
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(101, registrantChange.Id);
+                Assert.AreEqual(101, registrantChange.AccountId);
+                Assert.AreEqual(101, registrantChange.ContactId);
+                Assert.AreEqual(101, registrantChange.DomainId);
+                Assert.AreEqual("new", registrantChange.State);
+                Assert.IsInstanceOf<Dictionary<string, string>>(registrantChange.ExtendedAttributes);
+                Assert.AreEqual(true, registrantChange.RegistryOwnerChange);
+                Assert.AreEqual(null, registrantChange.IrtLockLiftedBy);
+
+                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+            });
+        }
+
+        [Test]
+        [TestCase(1010,
+        "https://api.sandbox.dnsimple.com/v2/1010/registrar/registrant_changes?sort=id:asc&per_page=42&page=7")]
+        public void ListRegistrantChangesWithSortingAndFiltering(long accountId, string expectedUrl)
+        {
+            var client = new MockDnsimpleClient(ListRegistrantChangeFixture);
+            var options = new RegistrantChangesListOptions
+            {
+                Pagination = new Pagination
+                {
+                    PerPage = 42,
+                    Page = 7
+                }
+
+            }.SortById(Order.asc);
+
+            client.Registrar.ListRegistrantChanges(accountId, options);
+
+            Assert.AreEqual(expectedUrl, client.RequestSentTo());
+        }
+
+
+        [Test]
+        [TestCase(1010, 101,
+        "https://api.sandbox.dnsimple.com/v2/1010/registrar/registrant_changes/101")]
+        public void DeleteRegistrantChange(long accountId, long registrantChangeId, string expectedUrl)
+        {
+            var client = new MockDnsimpleClient(DeleteRegistrantChangeFixture);
+            var response = client.Registrar.DeleteRegistrantChange(accountId, registrantChangeId);
+            var data = response.Data;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(true, response.IsEmpty);
+                // data is an empty RegistrantChange object
+                Assert.AreEqual(0, data.Id);
+                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+            });
+        }
+
+
+        [Test]
+        [TestCase(1010, 101,
+        "https://api.sandbox.dnsimple.com/v2/1010/registrar/registrant_changes/101")]
+        public void DeleteRegistrantChangeAsync(long accountId, long registrantChangeId, string expectedUrl)
+        {
+            var client = new MockDnsimpleClient(DeleteRegistrantChangeAsyncFixture);
+            var response = client.Registrar.DeleteRegistrantChange(accountId, registrantChangeId);
+            var registrantChange = response.Data;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(false, response.IsEmpty);
+                Assert.AreEqual(101, registrantChange.Id);
+                Assert.AreEqual(101, registrantChange.AccountId);
+                Assert.AreEqual(101, registrantChange.ContactId);
+                Assert.AreEqual(101, registrantChange.DomainId);
+                Assert.AreEqual("cancelling", registrantChange.State);
+                Assert.IsInstanceOf<Dictionary<string, string>>(registrantChange.ExtendedAttributes);
+                Assert.AreEqual(true, registrantChange.RegistryOwnerChange);
+                Assert.AreEqual(null, registrantChange.IrtLockLiftedBy);
+
+                Assert.AreEqual(expectedUrl, client.RequestSentTo());
+            });
+        }
 
         [Test]
         [TestCase(1010, "ruby.codes",

--- a/src/dnsimple-test/dnsimple-test.csproj
+++ b/src/dnsimple-test/dnsimple-test.csproj
@@ -425,6 +425,30 @@
     <Content Include="fixtures\v2\api\whoami\success.http">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="fixtures\v2\api\checkRegistrantChange\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\checkRegistrantChange\error-contactnotfound.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\checkRegistrantChange\error-domainnotfound.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\getRegistrantChange\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\createRegistrantChange\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\listRegistrantChanges\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\deleteRegistrantChange\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\deleteRegistrantChange\success_async.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="fixtures\v2\webhooks\account.billing_settings_update\example.http">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/dnsimple-test/fixtures/v2/api/checkRegistrantChange/error-contactnotfound.http
+++ b/src/dnsimple-test/fixtures/v2/api/checkRegistrantChange/error-contactnotfound.http
@@ -1,0 +1,14 @@
+HTTP/1.1 404
+server: nginx
+date: Tue, 22 Aug 2023 13:59:02 GMT
+content-type: application/json; charset=utf-8
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2395
+X-RateLimit-Reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: b1dd3f42-ebb9-42fd-a121-d595de96f667
+x-runtime: 0.019122
+strict-transport-security: max-age=63072000
+
+{"message":"Contact `21` not found"}

--- a/src/dnsimple-test/fixtures/v2/api/checkRegistrantChange/error-domainnotfound.http
+++ b/src/dnsimple-test/fixtures/v2/api/checkRegistrantChange/error-domainnotfound.http
@@ -1,0 +1,15 @@
+HTTP/1.1 404
+server: nginx
+date: Tue, 22 Aug 2023 11:09:40 GMT
+content-type: application/json; charset=utf-8
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2395
+X-RateLimit-Reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"cef1e7d85d0b9bfd25e81b812891d34f"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 5b0d8bfb-7b6a-40b5-a079-b640fd817e34
+x-runtime: 3.066249
+strict-transport-security: max-age=63072000
+
+{"message":"Domain `dnsimple-rraform.bio` not found"}

--- a/src/dnsimple-test/fixtures/v2/api/checkRegistrantChange/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/checkRegistrantChange/success.http
@@ -1,0 +1,15 @@
+HTTP/1.1 200
+server: nginx
+date: Tue, 22 Aug 2023 11:09:40 GMT
+content-type: application/json; charset=utf-8
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2395
+X-RateLimit-Reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"cef1e7d85d0b9bfd25e81b812891d34f"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 5b0d8bfb-7b6a-40b5-a079-b640fd817e34
+x-runtime: 3.066249
+strict-transport-security: max-age=63072000
+
+{"data":{"domain_id":101,"contact_id":101,"extended_attributes":[],"registry_owner_change":true}}

--- a/src/dnsimple-test/fixtures/v2/api/createRegistrantChange/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/createRegistrantChange/success.http
@@ -1,0 +1,14 @@
+HTTP/1.1 202
+server: nginx
+date: Tue, 22 Aug 2023 11:11:00 GMT
+content-type: application/json; charset=utf-8
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2395
+X-RateLimit-Reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: 26bf7ff9-2075-42b0-9431-1778c825b6b0
+x-runtime: 3.408950
+strict-transport-security: max-age=63072000
+
+{"data":{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}

--- a/src/dnsimple-test/fixtures/v2/api/deleteRegistrantChange/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/deleteRegistrantChange/success.http
@@ -1,0 +1,13 @@
+HTTP/1.1 204 No Content
+server: nginx
+date: Tue, 22 Aug 2023 11:14:44 GMT
+content-type: application/json; charset=utf-8
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2395
+X-RateLimit-Reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: b123e1f0-aa70-4abb-95cf-34f377c83ef4
+x-runtime: 0.114839
+strict-transport-security: max-age=63072000
+

--- a/src/dnsimple-test/fixtures/v2/api/deleteRegistrantChange/success_async.http
+++ b/src/dnsimple-test/fixtures/v2/api/deleteRegistrantChange/success_async.http
@@ -1,0 +1,14 @@
+HTTP/1.1 202
+server: nginx
+date: Tue, 22 Aug 2023 11:11:00 GMT
+content-type: application/json; charset=utf-8
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2395
+X-RateLimit-Reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: 26bf7ff9-2075-42b0-9431-1778c825b6b0
+x-runtime: 3.408950
+strict-transport-security: max-age=63072000
+
+{"data":{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"cancelling","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}}

--- a/src/dnsimple-test/fixtures/v2/api/getRegistrantChange/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/getRegistrantChange/success.http
@@ -1,0 +1,15 @@
+HTTP/1.1 200
+server: nginx
+date: Tue, 22 Aug 2023 11:13:58 GMT
+content-type: application/json; charset=utf-8
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2395
+X-RateLimit-Reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"76c5d4c7579b754b94a42ac7fa37a901"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: e910cd08-3f9c-4da4-9986-50dbe9c3bc55
+x-runtime: 0.022006
+strict-transport-security: max-age=63072000
+
+{"data":{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}

--- a/src/dnsimple-test/fixtures/v2/api/listRegistrantChanges/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/listRegistrantChanges/success.http
@@ -1,0 +1,15 @@
+HTTP/1.1 200
+server: nginx
+date: Tue, 22 Aug 2023 11:12:49 GMT
+content-type: application/json; charset=utf-8
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2395
+X-RateLimit-Reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"0049703ea058b06346df4c0e169eac29"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: fd0334ce-414a-4872-8889-e548e0b1410c
+x-runtime: 0.030759
+strict-transport-security: max-age=63072000
+
+{"data":[{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/src/dnsimple/Services/ListOptions/ListRegistrantChangesOptions.cs
+++ b/src/dnsimple/Services/ListOptions/ListRegistrantChangesOptions.cs
@@ -1,0 +1,66 @@
+namespace dnsimple.Services.ListOptions
+{
+  /// <summary>
+  /// Defines the options you may want to send to list registrant changes, such as
+  /// pagination, sorting and filtering.
+  /// </summary>
+  /// <see cref="ListOptionsWithFiltering"/>
+  public class RegistrantChangesListOptions : ListOptionsWithFiltering
+  {
+    /// <summary>
+    /// Sets the account to be filtered by.
+    /// </summary>
+    /// <param name="account">The account id we want to filter by.</param>
+    /// <returns>The instance of the <c>RegistrantChangesListOptions</c></returns>
+    public RegistrantChangesListOptions FilterByAccount(object accountId)
+    {
+      AddFilter(new Filter { Field = "account", Value = accountId.ToString() });
+      return this;
+    }
+
+    /// <summary>
+    /// Sets the domain to be filtered by.
+    /// </summary>
+    /// <param name="domainId">The domain ID</param>
+    /// <returns>The instance of the <c>RegistrantChangesListOptions</c></returns>
+    public RegistrantChangesListOptions FilterByDomain(long domainId)
+    {
+      AddFilter(new Filter { Field = "domain_id", Value = domainId.ToString() });
+      return this;
+    }
+
+    /// <summary>
+    /// Sets the contact to be filtered by.
+    /// </summary>
+    /// <param name="contactId">The contact ID</param>
+    /// <returns>The instance of the <c>RegistrantChangesListOptions</c></returns>
+    public RegistrantChangesListOptions FilterByContact(long contactId)
+    {
+      AddFilter(new Filter { Field = "contact_id", Value = contactId.ToString() });
+      return this;
+    }
+
+    /// <summary>
+    /// Sets the state to be filtered by.
+    /// </summary>
+    /// <param name="state">The state we want to filter by.</param>
+    /// <returns>The instance of the <c>RegistrantChangesListOptions</c></returns>
+    public RegistrantChangesListOptions FilterByState(string state)
+    {
+      AddFilter(new Filter { Field = "state", Value = state });
+      return this;
+    }
+
+    /// <summary>
+    /// Sets the order by which to sort by id.
+    /// </summary>
+    /// <param name="order">The order in which we want to sort (asc or desc)</param>
+    /// <returns>The instance of the <c>RegistrantChangesListOptions</c></returns>
+    /// <see cref="Order"/>
+    public RegistrantChangesListOptions SortById(Order order)
+    {
+      AddSortCriteria(new Sort { Field = "id", Order = order });
+      return this;
+    }
+  }
+}

--- a/src/dnsimple/Services/Paths.cs
+++ b/src/dnsimple/Services/Paths.cs
@@ -209,6 +209,22 @@ namespace dnsimple.Services
             return $"{ContactsPath(accountId)}/{contactId}";
         }
 
+        public static string CheckRegistrantChangePath(long accountId)
+        {
+            return $"{accountId}/registrar/registrant_changes/check";
+        }
+
+        public static string RegistrantChangePath(long accountId,
+            long registrantChangeId)
+        {
+            return $"{accountId}/registrar/registrant_changes/{registrantChangeId}";
+        }
+
+        public static string RegistrantChangesPath(long accountId)
+        {
+            return $"{accountId}/registrar/registrant_changes";
+        }
+
         public static string ServicesPath()
         {
             return "/services";

--- a/src/dnsimple/Services/ServiceBase.cs
+++ b/src/dnsimple/Services/ServiceBase.cs
@@ -60,7 +60,7 @@ namespace dnsimple.Services
 
         private string ExtractValueFromHeader(string headerName)
         {
-            return (string) Headers.Where(header =>
+            return (string)Headers.Where(header =>
                     header.Name != null && header.Name.Equals(headerName))
                 .First().Value;
         }
@@ -91,6 +91,35 @@ namespace dnsimple.Services
         public SimpleResponse(IRestResponse response) : base(response)
         {
             Data = JsonTools<T>.DeserializeObject("data", JObject.Parse(response.Content));
+        }
+    }
+
+    /// <summary>
+    /// Represents a response from a call to the DNSimple API containing a
+    /// single object or an empty response (204 No Content).
+    /// </summary>
+    /// <typeparam name="T">The Data object type contained in the response</typeparam>
+    public class SimpleResponseOrEmpty<T> : Response
+    {
+        /// <summary>
+        /// Represents the <c>struct</c> containing the data.
+        /// </summary>
+        public T Data { get; protected set; }
+
+        public bool IsEmpty { get; protected set; }
+
+        public SimpleResponseOrEmpty(IRestResponse response) : base(response)
+        {
+            if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
+            {
+                Data = default(T);
+                IsEmpty = true;
+            }
+            else
+            {
+                Data = JsonTools<T>.DeserializeObject("data", JObject.Parse(response.Content));
+                IsEmpty = false;
+            }
         }
     }
 


### PR DESCRIPTION
This PR introduces 5 new endpoints that are part of the domain contact management API that was introduced in https://github.com/dnsimple/dnsimple-developer/pull/501.

The following endpoints have been added:
- **listRegistrantChanges**: GET `/{account}/registrar/registrant_changes`
- **createRegistrantChange**: POST `/{account}/registrar/registrant_changes`
- **checkRegistrantChange**: POST `/{account}/registrar/registrant_changes/check`
- **getRegistrantChange**: GET `/{account}/registrar/registrant_changes/{registrantchange}`
- **deleteRegistrantChange**: DELETE `/{account}/registrar/registrant_changes/{registrantchange}`

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1729
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/18