### PR TITLE
Domain transfer lock API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ FEATURES:
 - NEW: Added `Dnsimple.Registrar.ListRegistrantChanges` to lists the registrant changes for a domain. (#140)
 - NEW: Added `Dnsimple.Registrar.DeleteRegistrantChange` to cancel an ongoing registrant change from the account. (#140)
 
-- NEW: Added `Dnsimple.Registrar.EnableDomainTransferLock` to enable the domain transfer lock for a domain. ()
-- NEW: Added `Dnsimple.Registrar.DisableDomainTransferLock` to disable the domain transfer lock for a domain. ()
-- NEW: Added `Dnsimple.Registrar.GetDomainTransferLock` to get the domain transfer lock status for a domain. ()
+- NEW: Added `Dnsimple.Registrar.EnableDomainTransferLock` to enable the domain transfer lock for a domain. (#142)
+- NEW: Added `Dnsimple.Registrar.DisableDomainTransferLock` to disable the domain transfer lock for a domain. (#142)
+- NEW: Added `Dnsimple.Registrar.GetDomainTransferLock` to get the domain transfer lock status for a domain. (#142)
 
 ## 0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ FEATURES:
 - NEW: Added `Dnsimple.Registrar.ListRegistrantChanges` to lists the registrant changes for a domain. (#140)
 - NEW: Added `Dnsimple.Registrar.DeleteRegistrantChange` to cancel an ongoing registrant change from the account. (#140)
 
+- NEW: Added `Dnsimple.Registrar.EnableDomainTransferLock` to enable the domain transfer lock for a domain. ()
+- NEW: Added `Dnsimple.Registrar.DisableDomainTransferLock` to disable the domain transfer lock for a domain. ()
+- NEW: Added `Dnsimple.Registrar.GetDomainTransferLock` to get the domain transfer lock status for a domain. ()
+
 ## 0.17.0
 
 ENHANCEMENTS:

--- a/src/dnsimple-test/Services/RegistrarTransferLockTest.cs
+++ b/src/dnsimple-test/Services/RegistrarTransferLockTest.cs
@@ -1,0 +1,69 @@
+using NUnit.Framework;
+using RestSharp;
+
+namespace dnsimple_test.Services
+{
+  [TestFixture]
+  public class RegistrarTransferLockTest
+  {
+
+    private const string EnableDomainTransferLockFixture =
+        "enableDomainTransferLock/success.http";
+
+    private const string DisableDomainTransferLockFixture =
+        "disableDomainTransferLock/success.http";
+
+    private const string GetDomainTransferLockFixture =
+        "getDomainTransferLock/success.http";
+
+    [Test]
+    [TestCase(1010, "42", "https://api.sandbox.dnsimple.com/v2/1010/registrar/domains/42/transfer_lock")]
+    [TestCase(1010, "ruby.codes", "https://api.sandbox.dnsimple.com/v2/1010/registrar/domains/ruby.codes/transfer_lock")]
+    public void EnableDomainTransferLock(long accountId, string domain, string expectedUrl)
+    {
+      var client = new MockDnsimpleClient(EnableDomainTransferLockFixture);
+      var transferLockStatus = client.Registrar.EnableDomainTransferLock(accountId, domain).Data;
+
+      Assert.Multiple(() =>
+      {
+        Assert.That(transferLockStatus.Enabled, Is.True);
+
+        Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
+        Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+      });
+    }
+
+    [Test]
+    [TestCase(1010, "42", "https://api.sandbox.dnsimple.com/v2/1010/registrar/domains/42/transfer_lock")]
+    [TestCase(1010, "ruby.codes", "https://api.sandbox.dnsimple.com/v2/1010/registrar/domains/ruby.codes/transfer_lock")]
+    public void DisableDomainTransferLock(long accountId, string domain, string expectedUrl)
+    {
+      var client = new MockDnsimpleClient(DisableDomainTransferLockFixture);
+      var transferLockStatus = client.Registrar.DisableDomainTransferLock(accountId, domain).Data;
+
+      Assert.Multiple(() =>
+      {
+        Assert.That(transferLockStatus.Enabled, Is.False);
+
+        Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
+        Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+      });
+    }
+
+    [Test]
+    [TestCase(1010, "ruby.codes", "https://api.sandbox.dnsimple.com/v2/1010/registrar/domains/ruby.codes/transfer_lock")]
+    public void GetDomainTransferLock(long accountId, string domain, string expectedUrl)
+    {
+      var client = new MockDnsimpleClient(GetDomainTransferLockFixture);
+      var transferLockStatus = client.Registrar.GetDomainTransferLock(accountId, domain).Data;
+
+      Assert.Multiple(() =>
+      {
+        Assert.That(transferLockStatus.Enabled, Is.True);
+
+        Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
+        Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.GET));
+      });
+    }
+  }
+}

--- a/src/dnsimple-test/dnsimple-test.csproj
+++ b/src/dnsimple-test/dnsimple-test.csproj
@@ -164,6 +164,15 @@
     <Content Include="fixtures\v2\api\enableVanityNameServers\success.http">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="fixtures\v2\api\enableDomainTransferLock\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\disableDomainTransferLock\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures\v2\api\getDomainTransferLock\success.http">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="fixtures\v2\api\enableWhoisPrivacy\created.http">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/dnsimple-test/fixtures/v2/api/disableDomainTransferLock/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/disableDomainTransferLock/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 15 Aug 2023 09:58:37 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1488538623
+ETag: W/"fc2368a31a1b6a3afcca33bb37ff6b9d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8b0fe49a-c810-4552-84ab-a1cd9b4a7786
+X-Runtime: 0.024780
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"enabled":false}}

--- a/src/dnsimple-test/fixtures/v2/api/enableDomainTransferLock/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/enableDomainTransferLock/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Tue, 15 Aug 2023 09:58:37 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1488538623
+ETag: W/"fc2368a31a1b6a3afcca33bb37ff6b9d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8b0fe49a-c810-4552-84ab-a1cd9b4a7786
+X-Runtime: 0.024780
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"enabled":true}}

--- a/src/dnsimple-test/fixtures/v2/api/getDomainTransferLock/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/getDomainTransferLock/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 15 Aug 2023 09:58:37 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1488538623
+ETag: W/"fc2368a31a1b6a3afcca33bb37ff6b9d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8b0fe49a-c810-4552-84ab-a1cd9b4a7786
+X-Runtime: 0.024780
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"enabled":true}}

--- a/src/dnsimple/Services/Paths.cs
+++ b/src/dnsimple/Services/Paths.cs
@@ -6,7 +6,7 @@ namespace dnsimple.Services
         {
             return $"/{accountId}/billing/charges";
         }
-        
+
         public static string CollaboratorsPath(long accountId,
             string domainIdentifier)
         {
@@ -298,6 +298,11 @@ namespace dnsimple.Services
         public static string AutoRenewalPath(long accountId, string domain)
         {
             return $"{RegistrarPath(accountId, domain)}/auto_renewal";
+        }
+
+        public static string TransferLockPath(long accountId, string domain)
+        {
+            return $"{RegistrarPath(accountId, domain)}/transfer_lock";
         }
 
         public static string VanityDelegationPath(long accountId, string domain)

--- a/src/dnsimple/Services/RegistrarTransferLock.cs
+++ b/src/dnsimple/Services/RegistrarTransferLock.cs
@@ -1,0 +1,67 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using RestSharp;
+using static dnsimple.Services.Paths;
+
+namespace dnsimple.Services
+{
+  /// <inheritdoc cref="RegistrarService"/>
+  /// <see>https://developer.dnsimple.com/v2/registrar/transfer-lock</see>
+  public partial class RegistrarService
+  {
+    /// <summary>
+    /// Enables the transfer lock for a domain.
+    /// </summary>
+    /// <param name="accountId">The account ID</param>
+    /// <param name="domain">The domain name</param>
+    /// <returns>The status of the transfer lock wrapped in a response</returns>
+    /// <see>https://developer.dnsimple.com/v2/registrar/transfer-lock/#enableDomainTransferLock</see>
+    public SimpleResponse<TransferLockStatus> EnableDomainTransferLock(long accountId, string domain)
+    {
+      var builder = BuildRequestForPath(TransferLockPath(accountId, domain));
+      builder.Method(Method.POST);
+
+      return new SimpleResponse<TransferLockStatus>(Execute(builder.Request));
+    }
+
+    /// <summary>
+    /// Disables the transfer lock for a domain.
+    /// </summary>
+    /// <param name="accountId">The account ID</param>
+    /// <param name="domain">The domain name</param>
+    /// <returns>The status of the transfer lock wrapped in a response</returns>
+    /// <see>https://developer.dnsimple.com/v2/registrar/transfer-lock/#disableDomainTransferLock</see>
+    public SimpleResponse<TransferLockStatus> DisableDomainTransferLock(long accountId, string domain)
+    {
+      var builder = BuildRequestForPath(TransferLockPath(accountId, domain));
+      builder.Method(Method.DELETE);
+
+      return new SimpleResponse<TransferLockStatus>(Execute(builder.Request));
+    }
+
+    /// <summary>
+    /// Gets the transfer lock status for a domain.
+    /// </summary>
+    /// <param name="accountId">The account ID</param>
+    /// <param name="domain">The domain name</param>
+    /// <returns>The status of the transfer lock wrapped in a response</returns>
+    /// <see>https://developer.dnsimple.com/v2/registrar/transfer-lock/#getDomainTransferLock</see>
+    public SimpleResponse<TransferLockStatus> GetDomainTransferLock(long accountId, string domain)
+    {
+      var builder = BuildRequestForPath(TransferLockPath(accountId, domain));
+
+      return new SimpleResponse<TransferLockStatus>(Execute(builder.Request));
+    }
+  }
+
+  /// <summary>
+  /// Represents the Transfer Lock status for a domain
+  /// </summary>
+  /// <see>https://developer.dnsimple.com/v2/registrar/transfer-lock</see>
+  [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
+  public struct TransferLockStatus
+  {
+    public bool Enabled { get; set; }
+  }
+}


### PR DESCRIPTION
This PR introduces 3 new endpoints that are part of the domain transfer lock API that is introduced in https://github.com/dnsimple/dnsimple-developer/pull/519.

The following endpoints have been added:
- **getDomainTransferLock**: GET `/{account}/registrar/domains/{domain}/transfer_lock`
- **enableDomainTransferLock**: POST `/{account}/registrar/domains/{domain}/transfer_lock`
- **disableDomainTransferLock**: DELETE `/{account}/registrar/domains/{domain}/transfer_lock`

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1728
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/18
