### PR TITLE
Update `EmailForward` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+- NEW: Added `AliasEmail` to `EmailForward`
+- CHANGED: Deprecated `From` and `To` fields in `EmailForward`
+
 ## 0.18.1
 
 - HOUSEKEEPING: Bump nunit from 4.0.1 to 4.1.0 (#147)

--- a/src/dnsimple-test/Services/DomainsEmailForwardsTest.cs
+++ b/src/dnsimple-test/Services/DomainsEmailForwardsTest.cs
@@ -27,11 +27,11 @@ namespace dnsimple_test.Services
             "deleteEmailForward/success.http";
 
         private DateTime CreatedAt { get; } = DateTime.ParseExact(
-            "2016-02-04T13:59:29Z", "yyyy-MM-ddTHH:mm:ssZ",
+            "2017-05-25T19:23:16Z", "yyyy-MM-ddTHH:mm:ssZ",
             CultureInfo.CurrentCulture);
 
         private DateTime UpdatedAt { get; } = DateTime.ParseExact(
-            "2016-02-04T13:59:29Z", "yyyy-MM-ddTHH:mm:ssZ",
+            "2017-05-25T19:23:16Z", "yyyy-MM-ddTHH:mm:ssZ",
             CultureInfo.CurrentCulture);
 
         [SetUp]
@@ -49,9 +49,9 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.That(emailForwards.Count, Is.EqualTo(2));
-                Assert.That(emailForwards.First().Id, Is.EqualTo(17702));
-                Assert.That(emailForwards.First().DomainId, Is.EqualTo(228963));
+                Assert.That(emailForwards.Count, Is.EqualTo(1));
+                Assert.That(emailForwards.First().Id, Is.EqualTo(24809));
+                Assert.That(emailForwards.First().DomainId, Is.EqualTo(235146));
                 Assert.That(emailForwards.First().From, Is.EqualTo(".*@a-domain.com"));
                 Assert.That(emailForwards.First().To, Is.EqualTo("jane.smith@example.com"));
                 Assert.That(emailForwards.First().CreatedAt, Is.EqualTo(CreatedAt));
@@ -73,7 +73,7 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.That(emailForwards.Data.Count, Is.EqualTo(2));
+                Assert.That(emailForwards.Data.Count, Is.EqualTo(1));
                 Assert.That(emailForwards.Pagination.CurrentPage, Is.EqualTo(1));
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
@@ -98,7 +98,7 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.That(emailForwards.Data.Count, Is.EqualTo(2));
+                Assert.That(emailForwards.Data.Count, Is.EqualTo(1));
                 Assert.That(emailForwards.Pagination.CurrentPage, Is.EqualTo(1));
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));

--- a/src/dnsimple-test/Services/DomainsEmailForwardsTest.cs
+++ b/src/dnsimple-test/Services/DomainsEmailForwardsTest.cs
@@ -54,6 +54,8 @@ namespace dnsimple_test.Services
                 Assert.That(emailForwards.First().DomainId, Is.EqualTo(235146));
                 Assert.That(emailForwards.First().From, Is.EqualTo(".*@a-domain.com"));
                 Assert.That(emailForwards.First().To, Is.EqualTo("jane.smith@example.com"));
+                Assert.That(emailForwards.First().AliasEmail, Is.EqualTo(".*@a-domain.com"));
+                Assert.That(emailForwards.First().DestinationEmail, Is.EqualTo("jane.smith@example.com"));
                 Assert.That(emailForwards.First().CreatedAt, Is.EqualTo(CreatedAt));
                 Assert.That(emailForwards.First().UpdatedAt, Is.EqualTo(UpdatedAt));
             });

--- a/src/dnsimple-test/fixtures/v2/api/createEmailForward/created.http
+++ b/src/dnsimple-test/fixtures/v2/api/createEmailForward/created.http
@@ -2,6 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Mon, 25 Jan 2021 13:54:40 GMT
 Content-Type: application/json; charset=utf-8
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4772

--- a/src/dnsimple-test/fixtures/v2/api/getEmailForward/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/getEmailForward/success.http
@@ -2,6 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 25 Jan 2021 13:56:24 GMT
 Content-Type: application/json; charset=utf-8
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4766

--- a/src/dnsimple-test/fixtures/v2/api/listEmailForwards/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/listEmailForwards/success.http
@@ -1,16 +1,16 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Thu, 04 Feb 2016 14:07:19 GMT
+Date: Fri, 17 May 2024 09:07:28 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
-Status: 200 OK
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3993
-X-RateLimit-Reset: 1454596043
-ETag: W/"3f10aae0cf0f0b81bdb4f58786ee1750"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4748
+X-RateLimit-Reset: 1715936948
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"a5eed9a071f03e10fc67001ccc647a94"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 6e3aa9d0-cb95-4186-93b0-630da372de86
-X-Runtime: 0.026287
-Strict-Transport-Security: max-age=31536000
+X-Request-Id: e42df983-a8a5-4123-8c74-fb89ab934aba
+X-Runtime: 0.025456
+Strict-Transport-Security: max-age=63072000
 
-{"data":[{"id":17702,"domain_id":228963,"from":".*@a-domain.com","to":"jane.smith@example.com","created_at":"2016-02-04T13:59:29Z","updated_at":"2016-02-04T13:59:29Z"},{"id":17703,"domain_id":228963,"from":"john@a-domain.com","to":"john@example.com","created_at":"2016-02-04T14:07:13Z","updated_at":"2016-02-04T14:07:13Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":24809,"domain_id":235146,"alias_email":".*@a-domain.com","destination_email":"jane.smith@example.com","created_at":"2017-05-25T19:23:16Z","updated_at":"2017-05-25T19:23:16Z","from":".*@a-domain.com","to":"jane.smith@example.com"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/src/dnsimple/Services/DomainsEmailForwards.cs
+++ b/src/dnsimple/Services/DomainsEmailForwards.cs
@@ -107,6 +107,7 @@ namespace dnsimple.Services
                 AliasName = value;
             }
         }
+        public string AliasEmail { get; set; }
 
         public string DestinationEmail { get; set; }
 

--- a/src/dnsimple/Services/DomainsEmailForwards.cs
+++ b/src/dnsimple/Services/DomainsEmailForwards.cs
@@ -93,6 +93,7 @@ namespace dnsimple.Services
 
         public string AliasName { get; set; }
 
+        [Obsolete("Deprecated, use AliasEmail or AliasName instead")]
         public string From
         {
             get
@@ -111,6 +112,7 @@ namespace dnsimple.Services
 
         public string DestinationEmail { get; set; }
 
+        [Obsolete("Deprecated, use DestinationEmail instead")]
         public string To
         {
             get


### PR DESCRIPTION
See https://github.com/dnsimple/dnsimple-developer/issues/315 for reference

In this PR:
- Add `alias_email` and `destination_email` fields to `EmailForward`
- Deprecate `from` and `to` fields in `EmailForward