### PR TITLE
Patch cycle - 2024 / Cycle 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
     strategy:
       matrix:
         dotnet-version:
-          - '6.0.x'
+          - '8.0.x'
+          - '9.0.x'
     steps:
       - uses: actions/checkout@v4
       - name: Setup dotnet ${{ matrix.dotnet-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
     strategy:
       matrix:
         dotnet-version:
-          - '8.0.x'
           - '9.0.x'
     steps:
       - uses: actions/checkout@v4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-dotnet-core 6.0.406
+dotnet-core 9.0.101

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+- CHANGED: Bumped `dotnet` to `9.0`
 - NEW: Added `AliasEmail` to `EmailForward`
 - CHANGED: Deprecated `From` and `To` fields in `EmailForward`
+- CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
+- HOUSEKEEPING: Bump Microsoft.NET.Test.Sdk from 17.9.0 to 17.10.0 (#152)
+- HOUSEKEEPING: Bump NUnit.Analyzers from 4.0.1 to 4.4.0 (#153)
 
 ## 0.18.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,15 +13,13 @@ cd dnsimple-csharp
 
 ### 2. Install dependencies
 
-- .NET Core SDK
+This project includes an ASDF `.tool-versions` file to set up the runtime:
 
-    From [https://dotnet.microsoft.com/download/](https://dotnet.microsoft.com/download/)
+```shell
+asdf install
+```
 
-    You can either use to install the .NET Core SDK
-        - Installers
-        - Binaries
-        - [Scripts](https://dotnet.microsoft.com/download/dotnet/scripts)
-        - Install [Visual Studio](https://visualstudio.microsoft.com/)
+Additional dependencies will be installed when [running the test suite](#testing).
 
 ### 3. Build and test
 

--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ We recommend to customize the user agent. If you are building a library or integ
 
 ## License
 
-Copyright (c) 2022 DNSimple Corporation. This is Free Software distributed under the MIT license.
+Copyright (c) 2024 DNSimple Corporation. This is Free Software distributed under the MIT license.

--- a/src/dnsimple-test/dnsimple-test.csproj
+++ b/src/dnsimple-test/dnsimple-test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>dnsimple_test</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/src/dnsimple/Services/DomainsCollaborators.cs
+++ b/src/dnsimple/Services/DomainsCollaborators.cs
@@ -19,6 +19,7 @@ namespace dnsimple.Services
         /// <param name="domainIdentifier">The domain name or id</param>
         /// <returns>A list of collaborators wrapped in a response</returns>
         /// <see>https://developer.dnsimple.com/v2/domains/collaborators/#listDomainCollaborators</see>
+        [Obsolete("Domain collaborators have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.")]
         public PaginatedResponse<Collaborator> ListCollaborators(long accountId, string domainIdentifier)
         {
             var builder = BuildRequestForPath(CollaboratorsPath(accountId, domainIdentifier));
@@ -34,6 +35,7 @@ namespace dnsimple.Services
         /// <param name="email">The email of the collaborator to be added/invited</param>
         /// <returns>The collaborator wrapped in a response.</returns>
         /// <see>https://developer.dnsimple.com/v2/domains/collaborators/#addDomainCollaborator</see>
+        [Obsolete("Domain collaborators have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.")]
         public SimpleResponse<Collaborator> AddCollaborator(long accountId, string domainIdentifier, string email)
         {
             if (string.IsNullOrEmpty(email))
@@ -58,6 +60,7 @@ namespace dnsimple.Services
         /// <param name="domainIdentifier">The domain name or id</param>
         /// <param name="collaboratorId">The collaborator id</param>
         /// <see>https://developer.dnsimple.com/v2/domains/collaborators/#removeDomainCollaborator</see>
+        [Obsolete("Domain collaborators have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.")]
         public EmptyResponse RemoveCollaborator(long accountId, string domainIdentifier, long collaboratorId)
         {
             var builder = BuildRequestForPath(RemoveCollaboratorPath(accountId, domainIdentifier, collaboratorId));


### PR DESCRIPTION
The changes to go out in the next version (0.19.0) are:

- CHANGED: Bumped `dotnet` to `9.0`
- NEW: Added `AliasEmail` to `EmailForward`
- CHANGED: Deprecated `From` and `To` fields in `EmailForward`
- CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
- HOUSEKEEPING: #152
- HOUSEKEEPING: #153

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/231