### PR TITLE
Patch cycle - 2025 / Cycle 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+## 0.19.1
+
+- HOUSEKEEPING: Bump NUnit3TestAdapter from 4.5.0 to 5.0.0 (#165)
+- HOUSEKEEPING: Bump Microsoft.NET.Test.Sdk and Newtonsoft.Json (#164)
+- HOUSEKEEPING: Bump NUnit.Analyzers from 4.4.0 to 4.6.0 (#163)
+- HOUSEKEEPING: Bump nosborn/github-action-markdown-cli from 3.3.0 to 3.4.0 (#162)
+- HOUSEKEEPING: Bump Moq from 4.20.70 to 4.20.72 (#160)
+- HOUSEKEEPING: Bump nunit from 4.1.0 to 4.3.2 (#156)
+
 ## 0.19.0
 
 - CHANGED: Bumped `dotnet` to `9.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
-## 0.19.1
-
 - HOUSEKEEPING: Bump NUnit3TestAdapter from 4.5.0 to 5.0.0 (#165)
 - HOUSEKEEPING: Bump Microsoft.NET.Test.Sdk and Newtonsoft.Json (#164)
 - HOUSEKEEPING: Bump NUnit.Analyzers from 4.4.0 to 4.6.0 (#163)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2024 DNSimple Corporation
+Copyright (c) 2025 DNSimple Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ We recommend to customize the user agent. If you are building a library or integ
 
 ## License
 
-Copyright (c) 2024 DNSimple Corporation. This is Free Software distributed under the MIT license.
+Copyright (c) 2025 DNSimple Corporation. This is Free Software distributed under the MIT license.

--- a/src/dnsimple/dnsimple.csproj
+++ b/src/dnsimple/dnsimple.csproj
@@ -9,15 +9,15 @@
     <PackageLicenseUrl>https://github.com/dnsimple/dnsimple-csharp/blob/main/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/dnsimple/dnsimple-csharp</PackageProjectUrl>
     <PackageReleaseNotes>
-      - CHANGED: Bumped `dotnet` to `9.0`
-      - NEW: Added `AliasEmail` to `EmailForward`
-      - CHANGED: Deprecated `From` and `To` fields in `EmailForward`
-      - CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
-      - HOUSEKEEPING: Bump Microsoft.NET.Test.Sdk from 17.9.0 to 17.10.0 (#152)
-      - HOUSEKEEPING: Bump NUnit.Analyzers from 4.0.1 to 4.4.0 (#153)
+      - HOUSEKEEPING: Bump NUnit3TestAdapter from 4.5.0 to 5.0.0 (#165)
+      - HOUSEKEEPING: Bump Microsoft.NET.Test.Sdk and Newtonsoft.Json (#164)
+      - HOUSEKEEPING: Bump NUnit.Analyzers from 4.4.0 to 4.6.0 (#163)
+      - HOUSEKEEPING: Bump nosborn/github-action-markdown-cli from 3.3.0 to 3.4.0 (#162)
+      - HOUSEKEEPING: Bump Moq from 4.20.70 to 4.20.72 (#160)
+      - HOUSEKEEPING: Bump nunit from 4.1.0 to 4.3.2 (#156)
     </PackageReleaseNotes>
     <PackageTags>dnsimple dns api domains</PackageTags>
-    <PackageVersion>0.19.0</PackageVersion>
+    <PackageVersion>0.19.1</PackageVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/dnsimple/dnsimple.csproj
+++ b/src/dnsimple/dnsimple.csproj
@@ -9,15 +9,15 @@
     <PackageLicenseUrl>https://github.com/dnsimple/dnsimple-csharp/blob/main/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/dnsimple/dnsimple-csharp</PackageProjectUrl>
     <PackageReleaseNotes>
-      - HOUSEKEEPING: Bump NUnit3TestAdapter from 4.5.0 to 5.0.0 (#165)
-      - HOUSEKEEPING: Bump Microsoft.NET.Test.Sdk and Newtonsoft.Json (#164)
-      - HOUSEKEEPING: Bump NUnit.Analyzers from 4.4.0 to 4.6.0 (#163)
-      - HOUSEKEEPING: Bump nosborn/github-action-markdown-cli from 3.3.0 to 3.4.0 (#162)
-      - HOUSEKEEPING: Bump Moq from 4.20.70 to 4.20.72 (#160)
-      - HOUSEKEEPING: Bump nunit from 4.1.0 to 4.3.2 (#156)
+      - CHANGED: Bumped `dotnet` to `9.0`
+      - NEW: Added `AliasEmail` to `EmailForward`
+      - CHANGED: Deprecated `From` and `To` fields in `EmailForward`
+      - CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
+      - HOUSEKEEPING: Bump Microsoft.NET.Test.Sdk from 17.9.0 to 17.10.0 (#152)
+      - HOUSEKEEPING: Bump NUnit.Analyzers from 4.0.1 to 4.4.0 (#153)
     </PackageReleaseNotes>
     <PackageTags>dnsimple dns api domains</PackageTags>
-    <PackageVersion>0.19.1</PackageVersion>
+    <PackageVersion>0.19.0</PackageVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/dnsimple/dnsimple.csproj
+++ b/src/dnsimple/dnsimple.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>DNSimple</Authors>
-    <Copyright>2024</Copyright>
+    <Copyright>2025</Copyright>
     <Description>The DNSimple API client for the .NET platform.</Description>
     <PackageId>DNSimple</PackageId>
     <PackageLicenseUrl>https://github.com/dnsimple/dnsimple-csharp/blob/main/LICENSE.txt</PackageLicenseUrl>


### PR DESCRIPTION
The changes to go out in the next version (0.19.1) are:
- HOUSEKEEPING: Bump NUnit3TestAdapter from 4.5.0 to 5.0.0 (#165)
- HOUSEKEEPING: Bump Microsoft.NET.Test.Sdk and Newtonsoft.Json (#164)
- HOUSEKEEPING: Bump NUnit.Analyzers from 4.4.0 to 4.6.0 (#163)
- HOUSEKEEPING: Bump nosborn/github-action-markdown-cli from 3.3.0 to 3.4.0 (#162)
- HOUSEKEEPING: Bump Moq from 4.20.70 to 4.20.72 (#160)
- HOUSEKEEPING: Bump nunit from 4.1.0 to 4.3.2 (#156)

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/295
Part of https://github.com/dnsimple/dnsimple-engineering/issues/294