### PR TITLE
Add domain push identifier support and account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Added `InitiatePushWithIdentifier` to initiate domain pushes using an account identifier.
+- Added `Name` to `Account`.
+
+### Deprecated
+
+- Deprecated `InitiatePush`. Use `InitiatePushWithIdentifier` instead.
+
 ## 1.2.1 - 2026-03-24
 
 ### Fixed

--- a/src/dnsimple-test/Services/AccountsTest.cs
+++ b/src/dnsimple-test/Services/AccountsTest.cs
@@ -27,6 +27,7 @@ namespace dnsimple_test.Services
             {
                 Assert.That(accountsData.Data.First().Id, Is.EqualTo(123));
                 Assert.That(accountsData.Data.First().Email, Is.EqualTo("john@example.com"));
+                Assert.That(accountsData.Data.First().Name, Is.EqualTo("John"));
                 Assert.That(accountsData.Data.First().PlanIdentifier, Is.EqualTo("dnsimple-personal"));
             });
         }

--- a/src/dnsimple-test/Services/DomainsPushesTest.cs
+++ b/src/dnsimple-test/Services/DomainsPushesTest.cs
@@ -58,6 +58,23 @@ namespace dnsimple_test.Services
         }
 
         [Test]
+        [TestCase(1010, "100", "https://api.sandbox.dnsimple.com/v2/1010/domains/100/pushes")]
+        public void InitiatePushWithIdentifier(long accountId, string domainIdentifier, string expectedUrl)
+        {
+            var client = new MockDnsimpleClient(InitiatePushFixture);
+            var push = client.Domains.InitiatePushWithIdentifier(accountId, domainIdentifier,
+                "abc123");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(push.Data.Id, Is.EqualTo(1));
+                Assert.That(push.Data.AccountId, Is.EqualTo(2020));
+
+                Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
+            });
+        }
+
+        [Test]
         [TestCase(1010, "https://api.sandbox.dnsimple.com/v2/1010/pushes")]
         [TestCase(1010, "https://api.sandbox.dnsimple.com/v2/1010/pushes")]
         public void ListPushes(long accountId, string expectedUrl)

--- a/src/dnsimple-test/fixtures/v2/api/accounts/success-account.http
+++ b/src/dnsimple-test/fixtures/v2/api/accounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/src/dnsimple-test/fixtures/v2/api/accounts/success-user.http
+++ b/src/dnsimple-test/fixtures/v2/api/accounts/success-user.http
@@ -17,5 +17,5 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
 

--- a/src/dnsimple-test/fixtures/v2/api/listAccounts/success-account.http
+++ b/src/dnsimple-test/fixtures/v2/api/listAccounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/src/dnsimple-test/fixtures/v2/api/listAccounts/success-user.http
+++ b/src/dnsimple-test/fixtures/v2/api/listAccounts/success-user.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}

--- a/src/dnsimple-test/fixtures/v2/api/whoami/success-account.http
+++ b/src/dnsimple-test/fixtures/v2/api/whoami/success-account.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}

--- a/src/dnsimple-test/fixtures/v2/api/whoami/success.http
+++ b/src/dnsimple-test/fixtures/v2/api/whoami/success.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}

--- a/src/dnsimple/Services/DomainsPushes.cs
+++ b/src/dnsimple/Services/DomainsPushes.cs
@@ -12,18 +12,39 @@ namespace dnsimple.Services
     public partial class DomainsService
     {
         /// <summary>
-        /// Initiates a pust of a domain to another DNSimple account.
+        /// Initiates a push of a domain to another DNSimple account using a domain push identifier.
+        /// </summary>
+        /// <param name="accountId">The account ID</param>
+        /// <param name="domainIdentifier">The domain name or ID</param>
+        /// <param name="newDomainPushIdentifier">The domain push identifier of the target account.</param>
+        /// <returns>The newly created push.</returns>
+        /// <see>https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush</see>
+        public SimpleResponse<Push> InitiatePushWithIdentifier(long accountId, string domainIdentifier, string newDomainPushIdentifier)
+        {
+            if(string.IsNullOrEmpty(newDomainPushIdentifier))
+                throw new ArgumentException("Domain push identifier cannot be null or empty");
+
+            var builder = BuildRequestForPath(InitiatePushPath(accountId, domainIdentifier));
+            builder.Method(Method.POST);
+            builder.AddJsonPayload(PushPayload("new_domain_push_identifier", newDomainPushIdentifier));
+
+            return new SimpleResponse<Push>(Execute(builder.Request));
+        }
+
+        /// <summary>
+        /// Initiates a push of a domain to another DNSimple account.
         /// </summary>
         /// <param name="accountId">The account ID</param>
         /// <param name="domainIdentifier">The domain name or ID</param>
         /// <param name="email">The email address of the target DNSimple account.</param>
         /// <returns>The newly created push.</returns>
         /// <see>https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush</see>
+        [Obsolete("Use InitiatePushWithIdentifier instead")]
         public SimpleResponse<Push> InitiatePush(long accountId, string domainIdentifier, string email)
         {
             if(string.IsNullOrEmpty(email))
                 throw new ArgumentException("Email cannot be null or empty");
-            
+
             var builder = BuildRequestForPath(InitiatePushPath(accountId, domainIdentifier));
             builder.Method(Method.POST);
             builder.AddJsonPayload(PushPayload("new_account_email", email));

--- a/src/dnsimple/Services/DomainsPushes.cs
+++ b/src/dnsimple/Services/DomainsPushes.cs
@@ -12,21 +12,21 @@ namespace dnsimple.Services
     public partial class DomainsService
     {
         /// <summary>
-        /// Initiates a push of a domain to another DNSimple account using a domain push identifier.
+        /// Initiates a push of a domain to another DNSimple account using an account identifier.
         /// </summary>
         /// <param name="accountId">The account ID</param>
         /// <param name="domainIdentifier">The domain name or ID</param>
-        /// <param name="newDomainPushIdentifier">The domain push identifier of the target account.</param>
+        /// <param name="newAccountIdentifier">The account identifier of the target account.</param>
         /// <returns>The newly created push.</returns>
         /// <see>https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush</see>
-        public SimpleResponse<Push> InitiatePushWithIdentifier(long accountId, string domainIdentifier, string newDomainPushIdentifier)
+        public SimpleResponse<Push> InitiatePushWithIdentifier(long accountId, string domainIdentifier, string newAccountIdentifier)
         {
-            if(string.IsNullOrEmpty(newDomainPushIdentifier))
-                throw new ArgumentException("Domain push identifier cannot be null or empty");
+            if(string.IsNullOrEmpty(newAccountIdentifier))
+                throw new ArgumentException("Account identifier cannot be null or empty");
 
             var builder = BuildRequestForPath(InitiatePushPath(accountId, domainIdentifier));
             builder.Method(Method.POST);
-            builder.AddJsonPayload(PushPayload("new_domain_push_identifier", newDomainPushIdentifier));
+            builder.AddJsonPayload(PushPayload("new_account_identifier", newAccountIdentifier));
 
             return new SimpleResponse<Push>(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/Identity.cs
+++ b/src/dnsimple/Services/Identity.cs
@@ -75,6 +75,7 @@ namespace dnsimple.Services
     {
         public long Id { get; set; }
         public string Email { get; set; }
+        public string Name { get; set; }
         public string PlanIdentifier { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }


### PR DESCRIPTION
## Summary
- Add `InitiatePushWithIdentifier` method for domain pushes
- Deprecate `InitiatePush` with email in favor of push identifier
- Add `Name` property to `Account` struct
- Update fixtures and tests

Closes dnsimple/dnsimple-engineering#425