### PR TITLE
Support trustee service in transfers

### DIFF
--- a/src/dnsimple-test/Services/RegistrarTest.cs
+++ b/src/dnsimple-test/Services/RegistrarTest.cs
@@ -475,6 +475,9 @@ namespace dnsimple_test.Services
             Assert.Multiple(() =>
             {
                 Assert.That(domain.State, Is.EqualTo("transferring"));
+                Assert.That(domain.AutoRenew, Is.False);
+                Assert.That(domain.WhoisPrivacy, Is.False);
+                Assert.That(domain.TrusteeService, Is.False);
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
@@ -610,6 +613,7 @@ namespace dnsimple_test.Services
                 Assert.That(domainTransfer.State, Is.EqualTo("cancelled"));
                 Assert.That(domainTransfer.AutoRenew, Is.False);
                 Assert.That(domainTransfer.WhoisPrivacy, Is.False);
+                Assert.That(domainTransfer.TrusteeService, Is.False);
                 Assert.That(domainTransfer.StatusDescription, Is.EqualTo("Canceled by customer"));
                 Assert.That(domainTransfer.CreatedAt, Is.EqualTo(Convert.ToDateTime("2020-06-05T18:08:00Z")));
                 Assert.That(domainTransfer.UpdatedAt, Is.EqualTo(Convert.ToDateTime("2020-06-05T18:10:01Z")));
@@ -631,6 +635,7 @@ namespace dnsimple_test.Services
                 Assert.That(domainTransfer.State, Is.EqualTo("transferring"));
                 Assert.That(domainTransfer.AutoRenew, Is.False);
                 Assert.That(domainTransfer.WhoisPrivacy, Is.False);
+                Assert.That(domainTransfer.TrusteeService, Is.False);
                 Assert.That(domainTransfer.StatusDescription, Is.Null);
                 Assert.That(domainTransfer.CreatedAt, Is.EqualTo(Convert.ToDateTime("2020-06-05T18:08:00Z")));
                 Assert.That(domainTransfer.UpdatedAt, Is.EqualTo(Convert.ToDateTime("2020-06-05T18:08:04Z")));

--- a/src/dnsimple/Services/Registrar.cs
+++ b/src/dnsimple/Services/Registrar.cs
@@ -357,6 +357,7 @@ namespace dnsimple.Services
         public string State { get; set; }
         public bool AutoRenew { get; set; }
         public bool WhoisPrivacy { get; set; }
+        public bool TrusteeService { get; set; }
         public string StatusDescription { get; set; }
 
         public DateTime CreatedAt { get; set; }
@@ -416,6 +417,7 @@ namespace dnsimple.Services
 
         public bool AutoRenew { get; set; }
         public bool WhoisPrivacy { get; set; }
+        public bool? TrusteeService { get; set; }
 
         public string AuthCode { get; set; }
         public string PremiumPrice { get; set; }


### PR DESCRIPTION
Updated **src/dnsimple/Services/Registrar.cs**
- Added `TrusteeService` field to the `DomainTransfer` response struct so the value is parsed from API responses
- Added `TrusteeService` field to `DomainTransferInput` so callers can opt into the trustee service when initiating a transfer

Addresses https://github.com/dnsimple/dnsimple-app/issues/34690
Belongs to https://github.com/dnsimple/dnsimple-business/issues/2641

## QA

(Optional for reviewers)

From the console (adjust `accountId`, `registrantId`, `domainName` and `base_url` accordingly) run `dotnet run --project QATest`

```csharp
using dnsimple;
using dnsimple.Services;

var token = Environment.GetEnvironmentVariable("TOKEN");
if (string.IsNullOrEmpty(token))
{
    Console.Error.WriteLine("ERROR: TOKEN environment variable is required");
    Environment.Exit(1);
}

const long accountId = 2;
const long registrantId = 27;
const string domainName = "example.com";

var client = new Client();
client.ChangeBaseUrlTo("http://api.dnsimple.localhost:3000");
client.AddCredentials(new OAuth2Credentials(token));

// Transfer a domain with trustee service enabled
try
{
    var transfer = client.Registrar.TransferDomain(accountId, domainName, new DomainTransferInput
    {
        RegistrantId = registrantId,
        AuthCode = "x1y2z3",
        TrusteeService = true,
    }).Data;
    Console.WriteLine($"transfer domain_id={transfer.DomainId} trustee_service={transfer.TrusteeService} state={transfer.State}");

    // Get the domain transfer to verify
    transfer = client.Registrar.GetDomainTransfer(accountId, domainName, transfer.Id).Data;
    Console.WriteLine($"get_transfer id={transfer.Id} trustee_service={transfer.TrusteeService} state={transfer.State}");
}
catch (DnsimpleException e)
{
    Console.WriteLine(e.Message);
}
```

### QA results

```
TLD .COM does not support trustee service
```

```
Unable to complete transfer at the registrar. Invalid attribute value syntax [Parameter value syntax error; Invalid transfer authorisation code]
```

## Deployment Pre/Post tasks

- [x] PRE: Wait till release is ready to be made
- [x] POST: Create a release version

## Deployment Verification

- [x] Verify release is created