### PR TITLE
Upgrade RestSharp from 106.15.0 to 114.0.0

### DIFF
--- a/src/dnsimple-test/FixtureLoader.cs
+++ b/src/dnsimple-test/FixtureLoader.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using Castle.Core.Internal;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using RestSharp;
@@ -65,9 +64,9 @@ namespace dnsimple_test
             return File.ReadAllText(path);
         }
 
-        public List<Parameter> ExtractHeaders()
+        public List<HeaderParameter> ExtractHeaders()
         {
-            var headers = new List<Parameter>();
+            var headers = new List<HeaderParameter>();
 
             foreach (var line in GetLines())
             {
@@ -76,7 +75,7 @@ namespace dnsimple_test
                 if (line.Contains(':'))
                 {
                     var header = line.Split(':');
-                    headers.Add(new Parameter(header[0], header[1], ParameterType.HttpHeader));
+                    headers.Add(new HeaderParameter(header[0], header[1]));
                 }
             }
 

--- a/src/dnsimple-test/MockDnsimpleClient.cs
+++ b/src/dnsimple-test/MockDnsimpleClient.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using dnsimple;
 using dnsimple.Services;
 using Newtonsoft.Json.Linq;
 using RestSharp;
-using RestSharp.Extensions;
 using ICredentials = dnsimple.ICredentials;
 
 namespace dnsimple_test
@@ -82,7 +82,7 @@ namespace dnsimple_test
 
         public string RequestSentTo()
         {
-            return ((MockHttpService)Http).RequestUrlSent.UrlDecode();
+            return Uri.UnescapeDataString(((MockHttpService)Http).RequestUrlSent);
         }
 
         public Method HttpMethodUsed()
@@ -118,14 +118,16 @@ namespace dnsimple_test
             return new RequestBuilder(path);
         }
 
-        public override IRestResponse Execute(IRestRequest request)
+        public override RestResponse Execute(RestRequest request)
         {
-            RequestUrlSent = new RestClient($"{_baseUrl}/v2/").BuildUri(request).ToString();
+            using var client = new RestClient(new Uri($"{_baseUrl}/v2/"));
+            RequestUrlSent = client.BuildUri(request).ToString();
             MethodSent = request.Method;
             try
             {
-                PayloadSent = (string)request.Parameters.Find(x =>
-                    x.ContentType.Equals("application/json")).Value;
+                var bodyParameter = request.Parameters
+                    .FirstOrDefault(p => p.Type == ParameterType.RequestBody);
+                PayloadSent = bodyParameter?.Value?.ToString();
             }
             catch (Exception)
             {
@@ -156,14 +158,16 @@ namespace dnsimple_test
 
     public class MockResponse : RestResponse
     {
-        public MockResponse(FixtureLoader loader)
+        public MockResponse(FixtureLoader loader) : base(new RestRequest())
         {
             StatusCode = loader.ExtractStatusCode();
             Content = loader.ExtractJsonPayload();
             Headers = loader.ExtractHeaders();
+            IsSuccessStatusCode = (int)StatusCode >= 200 && (int)StatusCode < 300;
+            ResponseStatus = ResponseStatus.Completed;
         }
 
-        public void SetHeaders(List<Parameter> headers)
+        public void SetHeaders(List<HeaderParameter> headers)
         {
             Headers = headers;
         }

--- a/src/dnsimple-test/Services/CertificatesTest.cs
+++ b/src/dnsimple-test/Services/CertificatesTest.cs
@@ -346,7 +346,7 @@ namespace dnsimple_test.Services
                 Assert.That(certificateOrdered.CreatedAt, Is.EqualTo(Convert.ToDateTime("2020-06-18T18:54:17Z")));
                 Assert.That(certificateOrdered.UpdatedAt, Is.EqualTo(Convert.ToDateTime("2020-06-18T18:54:17Z")));
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -375,7 +375,7 @@ namespace dnsimple_test.Services
                 Assert.That(certificate.AlternateNames, Is.Empty);
                 Assert.That(certificate.AuthorityIdentifier, Is.EqualTo("letsencrypt"));
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -407,7 +407,7 @@ namespace dnsimple_test.Services
                 Assert.That(renewalPurchased.CreatedAt, Is.EqualTo(Convert.ToDateTime("2020-06-18T19:56:20Z")));
                 Assert.That(renewalPurchased.UpdatedAt, Is.EqualTo(Convert.ToDateTime("2020-06-18T19:56:20Z")));
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -440,7 +440,7 @@ namespace dnsimple_test.Services
                 Assert.That(renewalIssued.AlternateNames, Is.Empty);
                 Assert.That(renewalIssued.AuthorityIdentifier, Is.EqualTo("letsencrypt"));
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }

--- a/src/dnsimple-test/Services/ContactsTest.cs
+++ b/src/dnsimple-test/Services/ContactsTest.cs
@@ -142,7 +142,7 @@ namespace dnsimple_test.Services
                 Assert.That(created.Email, Is.EqualTo(contact.Email));
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
             });
         }
 
@@ -215,7 +215,7 @@ namespace dnsimple_test.Services
                 Assert.That(updated.AccountId, Is.EqualTo(accountId));
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.PATCH));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Patch));
             });
         }
 
@@ -233,7 +233,7 @@ namespace dnsimple_test.Services
                 });
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
             });
         }
 

--- a/src/dnsimple-test/Services/HttpTest.cs
+++ b/src/dnsimple-test/Services/HttpTest.cs
@@ -5,7 +5,6 @@ using System.Net;
 using dnsimple;
 using dnsimple.Services;
 using dnsimple.Services.ListOptions;
-using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -19,31 +18,23 @@ namespace dnsimple_test.Services
         [Test]
         public void ReturnsARequestBuilder()
         {
-            var http = new HttpService(new RestClient(), new RequestBuilder());
+            var http = new HttpService(new RestClientWrapper(), new RequestBuilder());
             Assert.That(http.RequestBuilder(""), Is.InstanceOf<RequestBuilder>());
-
         }
 
         [Test]
         public void InvalidRequest()
         {
-            var client = new Mock<IRestClient>();
-            var response = new Mock<IRestResponse>();
-            var request = new Mock<IRestRequest>();
-            var http = new HttpService(client.Object, new RequestBuilder());
-
-            response.SetupProperty(mock => mock.StatusCode,
-                HttpStatusCode.Unauthorized);
-            response.Setup(mock => mock.IsSuccessful).Returns(false);
-            response.Setup(mock => mock.Content)
-                .Returns("{\"message\": \"Authentication failed\"}");
-
-            client.Setup(mock => mock.Execute(request.Object))
-                .Returns(response.Object);
+            var response = new RestResponse(new RestRequest())
+            {
+                StatusCode = HttpStatusCode.Unauthorized,
+                Content = "{\"message\": \"Authentication failed\"}",
+                ResponseStatus = ResponseStatus.Completed,
+            };
 
             Assert.Throws(Is.TypeOf<AuthenticationException>()
                     .And.Message.EqualTo("Authentication failed"),
-                delegate { http.Execute(request.Object); });
+                delegate { HttpService.HandleExceptions(response); });
         }
 
         [Test]
@@ -144,7 +135,7 @@ namespace dnsimple_test.Services
         [Test]
         public void Resets()
         {
-            _builder.Method(Method.HEAD);
+            _builder.Method(Method.Head);
 
             Assert.That(_builder.Reset().Request, Is.Null);
         }
@@ -152,10 +143,10 @@ namespace dnsimple_test.Services
         [Test]
         public void SetsTheMethod()
         {
-            _builder.Method(Method.POST);
+            _builder.Method(Method.Post);
             var request = _builder.Request;
 
-            Assert.That(request.Method, Is.EqualTo(Method.POST));
+            Assert.That(request.Method, Is.EqualTo(Method.Post));
         }
 
         [Test]

--- a/src/dnsimple-test/Services/OAuth2Test.cs
+++ b/src/dnsimple-test/Services/OAuth2Test.cs
@@ -15,8 +15,10 @@ namespace dnsimple_test.Services
         private static void SetupMockHttpService(Mock<HttpService> http,
             IMock<RestResponse> mockRestResponse)
         {
-            var response = new RestResponse();
-            response.Content = mockRestResponse.Object.Content;
+            var response = new RestResponse(new RestRequest())
+            {
+                Content = mockRestResponse.Object.Content,
+            };
             http.Setup(mock =>
                     mock.RequestBuilder(It.IsAny<string>()))
                 .Returns(new RequestBuilder(""));
@@ -31,8 +33,8 @@ namespace dnsimple_test.Services
         [Test]
         public void ExchangeAuthorizationForToken()
         {
-            var http = new Mock<HttpService>(new RestClient(), new RequestBuilder());
-            var mockRestResponse = new Mock<RestResponse>();
+            var http = new Mock<HttpService>(new RestClientWrapper(), new RequestBuilder());
+            var mockRestResponse = new Mock<RestResponse>(new RestRequest());
             var oauthService = new OAuth2Service(http.Object);
 
             mockRestResponse.Object.Content =

--- a/src/dnsimple-test/Services/RegistrarAutoRenewalTest.cs
+++ b/src/dnsimple-test/Services/RegistrarAutoRenewalTest.cs
@@ -27,7 +27,7 @@ namespace dnsimple_test.Services
                     client.Registrar.EnableDomainAutoRenewal(accountId, domain);
                 });
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.PUT));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Put));
             });
         }
 
@@ -45,7 +45,7 @@ namespace dnsimple_test.Services
                     client.Registrar.DisableDomainAutoRenewal(accountId, domain);
                 });
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
             });
         }
     }

--- a/src/dnsimple-test/Services/RegistrarDelegationTest.cs
+++ b/src/dnsimple-test/Services/RegistrarDelegationTest.cs
@@ -99,7 +99,7 @@ namespace dnsimple_test.Services
                 Assert.That(newDelegation.Data, Is.EqualTo(delegation));
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.PUT));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Put));
             });
         }
 
@@ -130,7 +130,7 @@ namespace dnsimple_test.Services
                 Assert.That(vanityDelegation.First().UpdatedAt, Is.EqualTo(UpdatedAt));
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.PUT));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Put));
             });
         }
 
@@ -150,7 +150,7 @@ namespace dnsimple_test.Services
                 });
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
             });
         }
     }

--- a/src/dnsimple-test/Services/RegistrarTransferLockTest.cs
+++ b/src/dnsimple-test/Services/RegistrarTransferLockTest.cs
@@ -29,7 +29,7 @@ namespace dnsimple_test.Services
         Assert.That(transferLockStatus.Enabled, Is.True);
 
         Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-        Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+        Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
       });
     }
 
@@ -46,7 +46,7 @@ namespace dnsimple_test.Services
         Assert.That(transferLockStatus.Enabled, Is.False);
 
         Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-        Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+        Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
       });
     }
 
@@ -62,7 +62,7 @@ namespace dnsimple_test.Services
         Assert.That(transferLockStatus.Enabled, Is.True);
 
         Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-        Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.GET));
+        Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Get));
       });
     }
   }

--- a/src/dnsimple-test/Services/RegistrarWhoisPrivacyTest.cs
+++ b/src/dnsimple-test/Services/RegistrarWhoisPrivacyTest.cs
@@ -32,7 +32,7 @@ namespace dnsimple_test.Services
                 Assert.That(privacy.Enabled, Is.True);
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.PUT));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Put));
             });
         }
 
@@ -51,7 +51,7 @@ namespace dnsimple_test.Services
                 Assert.That(privacy.Enabled, Is.Null);
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.PUT));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Put));
             });
         }
 
@@ -70,7 +70,7 @@ namespace dnsimple_test.Services
                 Assert.That(privacy.Enabled, Is.False);
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
             });
         }
     }

--- a/src/dnsimple-test/Services/ServicesDomainsTest.cs
+++ b/src/dnsimple-test/Services/ServicesDomainsTest.cs
@@ -45,7 +45,7 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -62,7 +62,7 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }

--- a/src/dnsimple-test/Services/TemplateDomainsTest.cs
+++ b/src/dnsimple-test/Services/TemplateDomainsTest.cs
@@ -19,7 +19,7 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }

--- a/src/dnsimple-test/Services/TemplateRecordsTest.cs
+++ b/src/dnsimple-test/Services/TemplateRecordsTest.cs
@@ -132,7 +132,7 @@ namespace dnsimple_test.Services
                 Assert.That(record.Ttl, Is.EqualTo(templateRecord.Ttl));
                 Assert.That(record.Priority, Is.EqualTo(templateRecord.Priority));
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -168,7 +168,7 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }

--- a/src/dnsimple-test/Services/TemplatesTest.cs
+++ b/src/dnsimple-test/Services/TemplatesTest.cs
@@ -122,7 +122,7 @@ namespace dnsimple_test.Services
                 Assert.That(template.Sid, Is.EqualTo(templateData.Sid));
                 Assert.That(template.Description, Is.EqualTo(templateData.Description));
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -162,7 +162,7 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.PATCH));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Patch));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -178,7 +178,7 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }

--- a/src/dnsimple-test/Services/VanityNameServersTest.cs
+++ b/src/dnsimple-test/Services/VanityNameServersTest.cs
@@ -66,7 +66,7 @@ namespace dnsimple_test.Services
             {
                 Assert.That(vanityNameServers.Count, Is.EqualTo(4));
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.PUT));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Put));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -82,7 +82,7 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }

--- a/src/dnsimple-test/Services/WebhooksTest.cs
+++ b/src/dnsimple-test/Services/WebhooksTest.cs
@@ -88,7 +88,7 @@ namespace dnsimple_test.Services
             {
                 Assert.That(created.Url, Is.EqualTo(hook.Url));
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -118,7 +118,7 @@ namespace dnsimple_test.Services
 
             Assert.Multiple(() =>
             {
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }

--- a/src/dnsimple-test/Services/ZoneRecordsTest.cs
+++ b/src/dnsimple-test/Services/ZoneRecordsTest.cs
@@ -167,7 +167,7 @@ namespace dnsimple_test.Services
                 Assert.That(created.Type, Is.EqualTo("A"));
                 Assert.That(created.Regions, Contains.Item("global"));
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.POST));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Post));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -196,7 +196,7 @@ namespace dnsimple_test.Services
                 Assert.That(record.Regions, Contains.Item("IAD"));
                 Assert.That(record.SystemRecord, Is.False);
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.GET));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Get));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -234,7 +234,7 @@ namespace dnsimple_test.Services
                 Assert.That(record.SystemRecord, Is.False);
 
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.PATCH));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Patch));
             });
         }
 
@@ -253,7 +253,7 @@ namespace dnsimple_test.Services
                     client.Zones.DeleteZoneRecord(accountId, zoneId, recordId);
                 });
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }

--- a/src/dnsimple-test/Services/ZonesTest.cs
+++ b/src/dnsimple-test/Services/ZonesTest.cs
@@ -269,7 +269,7 @@ namespace dnsimple_test.Services
                 Assert.That(zone.CreatedAt, Is.EqualTo(Convert.ToDateTime("2022-09-28T04:45:24Z")));
                 Assert.That(zone.UpdatedAt, Is.EqualTo(Convert.ToDateTime("2023-07-06T11:19:48Z")));
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.PUT));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Put));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }
@@ -291,7 +291,7 @@ namespace dnsimple_test.Services
                 Assert.That(zone.CreatedAt, Is.EqualTo(Convert.ToDateTime("2022-09-28T04:45:24Z")));
                 Assert.That(zone.UpdatedAt, Is.EqualTo(Convert.ToDateTime("2023-08-08T04:19:52Z")));
 
-                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.DELETE));
+                Assert.That(client.HttpMethodUsed(), Is.EqualTo(Method.Delete));
                 Assert.That(client.RequestSentTo(), Is.EqualTo(expectedUrl));
             });
         }

--- a/src/dnsimple-test/dnsimple-test.csproj
+++ b/src/dnsimple-test/dnsimple-test.csproj
@@ -569,7 +569,7 @@
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="RestSharp" Version="106.15.0" />
+    <PackageReference Include="RestSharp" Version="114.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dnsimple/Credentials.cs
+++ b/src/dnsimple/Credentials.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using dnsimple.Services;
 using RestSharp.Authenticators;
 
@@ -12,7 +13,7 @@ namespace dnsimple
     /// </summary>
     public interface ICredentials
     {
-        AuthenticatorBase Authenticator { get; }
+        IAuthenticator Authenticator { get; }
     }
 
     /// <summary>
@@ -23,10 +24,10 @@ namespace dnsimple
     /// </code>
     public readonly struct BasicHttpCredentials : ICredentials
     {
-        public AuthenticatorBase Authenticator { get; }
+        public IAuthenticator Authenticator { get; }
 
         public BasicHttpCredentials(string name, string password) =>
-            Authenticator = new HttpBasicAuthenticator(name, password);
+            Authenticator = new HttpBasicAuthenticator(name, password, Encoding.UTF8);
     }
 
     /// <summary>
@@ -38,9 +39,9 @@ namespace dnsimple
     /// <seealso cref="OAuth2Service"/>
     public readonly struct OAuth2Credentials : ICredentials
     {
-        public AuthenticatorBase Authenticator { get; }
+        public IAuthenticator Authenticator { get; }
 
         public OAuth2Credentials(string token) =>
-            Authenticator = new OAuth2AuthorizationRequestHeaderAuthenticator(token, "Bearer");
+            Authenticator = new RestSharp.Authenticators.OAuth2.OAuth2AuthorizationRequestHeaderAuthenticator(token, "Bearer");
     }
 }

--- a/src/dnsimple/DNSimple.cs
+++ b/src/dnsimple/DNSimple.cs
@@ -342,7 +342,7 @@ namespace dnsimple
         public void ChangeBaseUrlTo(string baseUrl)
         {
             BaseUrl = baseUrl;
-            RestClientWrapper.RestClient.BaseUrl = new Uri(VersionedBaseUrl());
+            RestClientWrapper.SetBaseUrl(new Uri(VersionedBaseUrl()));
         }
 
         /// <summary>
@@ -374,7 +374,7 @@ namespace dnsimple
         public void SetUserAgent(string customUserAgent)
         {
             UserAgent = $"{customUserAgent} {DefaultUserAgent}";
-            RestClientWrapper.RestClient.UserAgent = UserAgent;
+            RestClientWrapper.SetUserAgent(UserAgent);
         }
 
         /// <summary>
@@ -385,8 +385,7 @@ namespace dnsimple
         /// <see cref="RestClient"/>
         private void InitializeRestClient()
         {
-            RestClientWrapper.RestClient.BaseUrl = new Uri(VersionedBaseUrl());
-            RestClientWrapper.RestClient.UseJson();
+            RestClientWrapper.SetBaseUrl(new Uri(VersionedBaseUrl()));
         }
 
         /// <summary>
@@ -398,7 +397,7 @@ namespace dnsimple
         /// <see cref="OAuth2Service"/>
         private void InitializeServices()
         {
-            Http = new HttpService(RestClientWrapper.RestClient, new RequestBuilder());
+            Http = new HttpService(RestClientWrapper, new RequestBuilder());
             Accounts = new AccountsService(this);
             Certificates = new CertificatesService(this);
             Contacts = new ContactsService(this);

--- a/src/dnsimple/RequestBuilder.cs
+++ b/src/dnsimple/RequestBuilder.cs
@@ -12,7 +12,7 @@ namespace dnsimple
     public class RequestBuilder
     {
         /// <summary>
-        /// Represents the <c>RestRequest</c> we will be issuing. 
+        /// Represents the <c>RestRequest</c> we will be issuing.
         /// </summary>
         public RestRequest Request { get; private set; }
 
@@ -32,14 +32,14 @@ namespace dnsimple
         ///         var builder = new RequestBuilder("/whoami");
         ///     </code>
         /// </example>
-        public RequestBuilder(string path) => 
+        public RequestBuilder(string path) =>
             AddPath(path);
-        
+
         /// <summary>
         /// Adds headers to the request.
         /// </summary>
         /// <param name="headers">The headers we want to add to the request.</param>
-        public void AddHeaders(Collection<KeyValuePair<string, string>> headers) => 
+        public void AddHeaders(Collection<KeyValuePair<string, string>> headers) =>
             Request.AddHeaders(headers);
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace dnsimple
                 AddParameter(parameter);
             }
         }
-        
+
         /// <summary>
         /// Adds a parameter to the request.
         /// </summary>
@@ -66,28 +66,28 @@ namespace dnsimple
                 Request.AddParameter(parameter.Key, parameter.Value);
             }
         }
-        
+
         /// <summary>
         /// Adds a JSON payload to the body of the request.
         /// </summary>
         /// <param name="payload">The object to be serialized and send in the
         /// body of the request.</param>
         public void AddJsonPayload(object payload)
-            => Request.AddJsonBody(JsonConvert.SerializeObject(payload));
-        
+            => Request.AddStringBody(JsonConvert.SerializeObject(payload), DataFormat.Json);
+
         /// <summary>
         /// Adds a JSON payload to the body of the request.
         /// </summary>
         /// <param name="payload">The object to be send in the body of the request.</param>
         public void AddJsonPayloadRaw(object payload)
-            => Request.AddJsonBody(payload);       
+            => Request.AddJsonBody(payload);
 
         /// <summary>
         /// Sets the HTTP method to be used.
         /// </summary>
         /// <param name="method"></param>
         /// <see cref="RestSharp.Method"/>
-        public void Method(Method method) => 
+        public void Method(Method method) =>
             Request.Method = method;
 
         /// <summary>
@@ -101,8 +101,10 @@ namespace dnsimple
         ///         builder.AddPath("/whoami");
         ///     </code>
         /// </example>
-        public void AddPath(string path) => 
-            Request = new RestRequest(path, DataFormat.Json);
+        public void AddPath(string path)
+        {
+            Request = new RestRequest(path) { RequestFormat = DataFormat.Json };
+        }
 
         /// <summary>
         /// Resets the <c>RequestBuilder</c> emptying the <c>Request</c> contained.

--- a/src/dnsimple/RestClientWrapper.cs
+++ b/src/dnsimple/RestClientWrapper.cs
@@ -1,4 +1,6 @@
+using System;
 using RestSharp;
+using RestSharp.Authenticators;
 
 namespace dnsimple
 {
@@ -8,21 +10,26 @@ namespace dnsimple
     /// <see cref="RestSharp.RestClient"/>
     public class RestClientWrapper
     {
+        private RestClient _restClient;
+        private IAuthenticator _authenticator;
+        private Uri _baseUrl;
+        private string _userAgent;
+
         /// <summary>
         /// The instance of the <c>RestSharp.RestClient</c>.
         /// </summary>
         /// <see cref="RestSharp.RestClient"/>
-        public RestClient RestClient { get; }
+        public virtual RestClient RestClient => _restClient ??= Build();
 
         /// <summary>
         /// Constructs a new <c>RestClientWrapper</c>
         /// </summary>
-        public RestClientWrapper() : this(new RestClient())
+        public RestClientWrapper()
         {
         }
 
         /// <summary>
-        /// Adds an <c>Authenticator</c> to the <c>RestSharp.RestClient</c>.
+        /// Adds an <c>Authenticator</c> to the underlying <c>RestClient</c>.
         /// </summary>
         /// <remarks>
         /// Authenticators are used to interact with the DNSimple API. They can
@@ -31,10 +38,33 @@ namespace dnsimple
         /// <param name="credentials">The credentials containing the authenticator to be used</param>
         /// <see cref="ICredentials"/>
         /// <see cref="RestSharp.Authenticators.IAuthenticator"/>
-        public virtual void AddAuthenticator(ICredentials credentials) => 
-            RestClient.Authenticator = credentials.Authenticator;
+        public virtual void AddAuthenticator(ICredentials credentials)
+        {
+            _authenticator = credentials.Authenticator;
+            _restClient = null;
+        }
 
-        private RestClientWrapper(RestClient restClient) => 
-            RestClient = restClient;
+        internal void SetBaseUrl(Uri baseUrl)
+        {
+            _baseUrl = baseUrl;
+            _restClient = null;
+        }
+
+        internal void SetUserAgent(string userAgent)
+        {
+            _userAgent = userAgent;
+            _restClient = null;
+        }
+
+        private RestClient Build()
+        {
+            var options = new RestClientOptions
+            {
+                Authenticator = _authenticator,
+                UserAgent = _userAgent,
+            };
+            if (_baseUrl != null) options.BaseUrl = _baseUrl;
+            return new RestClient(options);
+        }
     }
 }

--- a/src/dnsimple/Services/Certificates.cs
+++ b/src/dnsimple/Services/Certificates.cs
@@ -92,7 +92,7 @@ namespace dnsimple.Services
         public SimpleResponse<CertificatePurchase> PurchaseLetsEncryptCertificate(long accountId, string domainIdentifier, LetsencryptCertificateAttributes attributes)
         {
             var builder = BuildRequestForPath(PurchaseLetsEncryptCertificatePath(accountId, domainIdentifier));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(attributes);
 
             return new SimpleResponse<CertificatePurchase>(Execute(builder.Request));
@@ -110,7 +110,7 @@ namespace dnsimple.Services
         public SimpleResponse<Certificate> IssueLetsEncryptCertificate(long accountId, string domainIdentifier, long certificateId)
         {
             var builder = BuildRequestForPath(IssueLetsEncryptCertificatePath(accountId, domainIdentifier, certificateId));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
 
             return new SimpleResponse<Certificate>(Execute(builder.Request));
         }
@@ -128,7 +128,7 @@ namespace dnsimple.Services
         public SimpleResponse<CertificateRenewal> PurchaseLetsEncryptCertificateRenewal(long accountId, string domainIdentifier, long certificateId, LetsencryptCertificateAttributes attributes)
         {
             var builder = BuildRequestForPath(LetsEncryptCertificateRenewalPath(accountId, domainIdentifier, certificateId));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(attributes);
 
             return new SimpleResponse<CertificateRenewal>(Execute(builder.Request));
@@ -145,7 +145,7 @@ namespace dnsimple.Services
         public SimpleResponse<Certificate> IssueLetsEncryptCertificateRenewal(long accountId, string domainIdentifier, long certificateId, long certificateRenewalId)
         {
             var builder = BuildRequestForPath(IssueLetsEncryptCertificateRenewalPath(accountId, domainIdentifier, certificateId, certificateRenewalId));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
 
             return new SimpleResponse<Certificate>(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/Contacts.cs
+++ b/src/dnsimple/Services/Contacts.cs
@@ -49,7 +49,7 @@ namespace dnsimple.Services
         public SimpleResponse<Contact> CreateContact(long accountId, Contact contact)
         {
             var builder = BuildRequestForPath(ContactsPath(accountId));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(contact);
 
             return new SimpleResponse<Contact>(Execute(builder.Request));
@@ -82,7 +82,7 @@ namespace dnsimple.Services
         public SimpleResponse<Contact> UpdateContact(long accountId, long contactId, Contact contact)
         {
             var builder = BuildRequestForPath(ContactPath(accountId, contactId));
-            builder.Method(Method.PATCH);
+            builder.Method(Method.Patch);
             builder.AddJsonPayload(new UpdateContact(contact));
 
             return new SimpleResponse<Contact>(Execute(builder.Request));
@@ -97,7 +97,7 @@ namespace dnsimple.Services
         public EmptyResponse DeleteContact(long accountId, long contactId)
         {
             var builder = BuildRequestForPath(ContactPath(accountId, contactId));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/Domains.cs
+++ b/src/dnsimple/Services/Domains.cs
@@ -58,7 +58,7 @@ namespace dnsimple.Services
         public SimpleResponse<Domain> CreateDomain(long accountId, Domain domain)
         {
             var builder = BuildRequestForPath(DomainsPath(accountId));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(domain);
 
             return new SimpleResponse<Domain>(Execute(builder.Request));
@@ -74,7 +74,7 @@ namespace dnsimple.Services
         public EmptyResponse DeleteDomain(long accountId, string domainIdentifier)
         {
             var builder = BuildRequestForPath(DeleteDomainPath(accountId, domainIdentifier));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/DomainsDelegationSignerRecords.cs
+++ b/src/dnsimple/Services/DomainsDelegationSignerRecords.cs
@@ -39,7 +39,7 @@ namespace dnsimple.Services
         public SimpleResponse<DelegationSignerRecord> CreateDelegationSignerRecord(long accountId, string domainIdentifier, DelegationSignerRecord record)
         {
             var builder = BuildRequestForPath(DsRecordsPath(accountId, domainIdentifier));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(record);
 
             if (record.Algorithm.Trim().Equals(""))
@@ -73,7 +73,7 @@ namespace dnsimple.Services
         public EmptyResponse DeleteDelegationSignerRecord(long accountId, string domainIdentifier, int recordId)
         {
             var builder = BuildRequestForPath(DsRecordPath(accountId, domainIdentifier, recordId));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/DomainsDnssec.cs
+++ b/src/dnsimple/Services/DomainsDnssec.cs
@@ -38,7 +38,7 @@ namespace dnsimple.Services
         public SimpleResponse<DnssecStatus> EnableDnssec(long accountId, string domainIdentifier)
         {
             var builder = BuildRequestForPath(DnssecPath(accountId, domainIdentifier));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
 
             return new SimpleResponse<DnssecStatus>(Execute(builder.Request));
         }
@@ -58,7 +58,7 @@ namespace dnsimple.Services
         public EmptyResponse DisableDnssec(long accountId, string domainIdentifier)
         {
             var builder = BuildRequestForPath(DnssecPath(accountId,domainIdentifier));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/DomainsEmailForwards.cs
+++ b/src/dnsimple/Services/DomainsEmailForwards.cs
@@ -42,7 +42,7 @@ namespace dnsimple.Services
         public SimpleResponse<EmailForward> CreateEmailForward(long accountId, string domainIdentifier, EmailForward record)
         {
             var builder = BuildRequestForPath(EmailForwardsPath(accountId, domainIdentifier));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(record);
 
             if (record.DestinationEmail.Trim().Equals("") || record.AliasName.Trim().Equals(""))
@@ -76,7 +76,7 @@ namespace dnsimple.Services
         public EmptyResponse DeleteEmailForward(long accountId, string domainIdentifier, int emailForwardId)
         {
             var builder = BuildRequestForPath(EmailForwardPath(accountId, domainIdentifier, emailForwardId));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/DomainsPushes.cs
+++ b/src/dnsimple/Services/DomainsPushes.cs
@@ -25,7 +25,7 @@ namespace dnsimple.Services
                 throw new ArgumentException("Account identifier cannot be null or empty");
 
             var builder = BuildRequestForPath(InitiatePushPath(accountId, domainIdentifier));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(PushPayload("new_account_identifier", newAccountIdentifier));
 
             return new SimpleResponse<Push>(Execute(builder.Request));
@@ -46,7 +46,7 @@ namespace dnsimple.Services
                 throw new ArgumentException("Email cannot be null or empty");
 
             var builder = BuildRequestForPath(InitiatePushPath(accountId, domainIdentifier));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(PushPayload("new_account_email", email));
 
             return new SimpleResponse<Push>(Execute(builder.Request));
@@ -77,7 +77,7 @@ namespace dnsimple.Services
         public EmptyResponse AcceptPush(long accountId, long pushId, long contactId)
         {
             var builder = BuildRequestForPath(PushPath(accountId, pushId));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(PushPayload("contact_id", contactId.ToString()));
 
             return new EmptyResponse(Execute(builder.Request));
@@ -92,18 +92,14 @@ namespace dnsimple.Services
         public EmptyResponse RejectPush(int accountId, int pushId)
         {
             var builder = BuildRequestForPath(PushPath(accountId, pushId));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }
 
-        private static JsonObject PushPayload(string key, string value)
+        private static Dictionary<string, object> PushPayload(string key, string value)
         {
-            var payload = new JsonObject
-            {
-                new KeyValuePair<string, object>(key, value)
-            };
-            return payload;
+            return new Dictionary<string, object> { { key, value } };
         }
     }
 

--- a/src/dnsimple/Services/Http.cs
+++ b/src/dnsimple/Services/Http.cs
@@ -10,22 +10,19 @@ namespace dnsimple.Services
     public class HttpService
     {
         private readonly RequestBuilder _builder;
-        private IRestClient RestClient { get; }
+        private RestClientWrapper ClientWrapper { get; }
 
         protected HttpService() {}
 
         /// <summary>
         /// Constructs the HTTP service by passing an instance of a
-        /// <c>RestClient</c> and <c>RequestBuilder</c> objects.
+        /// <c>RestClientWrapper</c> and <c>RequestBuilder</c> objects.
         /// </summary>
-        /// <param name="restClient">RestClient instance to be used.</param>
+        /// <param name="clientWrapper">RestClientWrapper instance to be used.</param>
         /// <param name="builder">RequestBuilder instance to be used.</param>
-        /// 
-        /// <see cref="IRestClient"/>
-        /// <see cref="RequestBuilder"/>
-        public HttpService(IRestClient restClient, RequestBuilder builder)
+        public HttpService(RestClientWrapper clientWrapper, RequestBuilder builder)
         {
-            RestClient = restClient;
+            ClientWrapper = clientWrapper;
             _builder = builder;
         }
 
@@ -37,7 +34,7 @@ namespace dnsimple.Services
         ///     var builder = new RequestBuilder("/whoami");
         /// </code>
         /// </example>
-        /// 
+        ///
         /// <param name="path">Path to the resource</param>
         /// <returns><c>RequestBuilder</c> instance.</returns>
         public virtual RequestBuilder RequestBuilder(string path)
@@ -51,31 +48,29 @@ namespace dnsimple.Services
         /// Executes the request passed (GET, POST, etc.)
         /// </summary>
         /// <remarks>
-        /// The <c>RestRequest</c> instance will have been build with a
+        /// The <c>RestRequest</c> instance will have been built with a
         /// <c>RequestBuilder</c> and contains all the information
         /// (headers and parameters) needed to successfully issue the
         /// request to the server.
         /// </remarks>
         /// <param name="request"><c>RestRequest</c></param>
         /// <returns>
-        /// A <c>JToken</c> object representing the JSON payload returned
-        /// by the API call.
+        /// The <c>RestResponse</c> returned by the API call.
         /// </returns>
-        /// <see cref="JToken"/>
-        public virtual IRestResponse Execute(IRestRequest request)
+        public virtual RestResponse Execute(RestRequest request)
         {
-            var response = RestClient.Execute(request);
+            var response = ClientWrapper.RestClient.Execute(request);
 
             if (!response.IsSuccessful) HandleExceptions(response);
 
             return response;
         }
 
-        private static void HandleExceptions(IRestResponse restResponse)
+        internal static void HandleExceptions(RestResponse restResponse)
         {
             var error = JObject.Parse(restResponse.Content);
             var message = error["message"]?.ToString();
-            
+
             switch (restResponse.StatusCode)
             {
                 case HttpStatusCode.BadRequest:

--- a/src/dnsimple/Services/OAuth2.cs
+++ b/src/dnsimple/Services/OAuth2.cs
@@ -59,7 +59,7 @@ namespace dnsimple.Services
         private RestRequest BuildRequest(string path, IReadOnlyDictionary<OAuthParams, string> arguments)
         {
             var builder = Http.RequestBuilder(path);
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddHeaders(Headers());
             builder.AddParameters(PostParameters(arguments));
             return builder.Request;

--- a/src/dnsimple/Services/Registrar.cs
+++ b/src/dnsimple/Services/Registrar.cs
@@ -58,7 +58,7 @@ namespace dnsimple.Services
         public SimpleResponse<DomainRegistration> RegisterDomain(long accountId, string domainName, DomainRegistrationInput domain)
         {
             var builder = BuildRequestForPath(RegisterDomainPath(accountId, domainName));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(domain);
 
             return new SimpleResponse<DomainRegistration>(Execute(builder.Request));
@@ -96,7 +96,7 @@ namespace dnsimple.Services
                 throw new DnsimpleException("Please provide an AuthCode");
             }
             var builder = BuildRequestForPath(TransferDomainPath(accountId, domainName));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(transferInput);
 
             return new SimpleResponse<DomainTransfer>(Execute(builder.Request));
@@ -127,7 +127,7 @@ namespace dnsimple.Services
         public SimpleResponse<RegistrantChangeCheck> CheckRegistrantChange(long accountId, CheckRegistrantChangeInput input)
         {
             var builder = BuildRequestForPath(CheckRegistrantChangePath(accountId));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(input);
 
             return new SimpleResponse<RegistrantChangeCheck>(Execute(builder.Request));
@@ -155,7 +155,7 @@ namespace dnsimple.Services
         public SimpleResponse<RegistrantChange> CreateRegistrantChange(long accountId, CreateRegistrantChangeInput input)
         {
             var builder = BuildRequestForPath(RegistrantChangesPath(accountId));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(input);
 
             return new SimpleResponse<RegistrantChange>(Execute(builder.Request));
@@ -187,7 +187,7 @@ namespace dnsimple.Services
         public SimpleResponseOrEmpty<RegistrantChange> DeleteRegistrantChange(long accountId, long registrantChangeId)
         {
             var builder = BuildRequestForPath(RegistrantChangePath(accountId, registrantChangeId));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new SimpleResponseOrEmpty<RegistrantChange>(Execute(builder.Request));
         }
@@ -204,7 +204,7 @@ namespace dnsimple.Services
         public SimpleResponse<DomainTransfer> CancelDomainTransfer(long accountId, string domainName, long domainTransferId)
         {
             var builder = BuildRequestForPath(DomainTransferPath(accountId, domainName, domainTransferId));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new SimpleResponse<DomainTransfer>(Execute(builder.Request));
         }
@@ -220,7 +220,7 @@ namespace dnsimple.Services
         public SimpleResponse<DomainRenewal> RenewDomain(long accountId, string domainName, DomainRenewalInput input)
         {
             var builder = BuildRequestForPath(RenewDomainPath(accountId, domainName));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(input);
 
             return new SimpleResponse<DomainRenewal>(Execute(builder.Request));
@@ -251,7 +251,7 @@ namespace dnsimple.Services
         public EmptyResponse TransferDomainOut(long accountId, string domainName)
         {
             var builder = BuildRequestForPath(DomainTransferOutPath(accountId, domainName));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/RegistrarAutoRenewal.cs
+++ b/src/dnsimple/Services/RegistrarAutoRenewal.cs
@@ -15,7 +15,7 @@ namespace dnsimple.Services
         /// <see>https://developer.dnsimple.com/v2/registrar/auto-renewal/#enableDomainAutoRenewal</see>
         public EmptyResponse EnableDomainAutoRenewal(long accountId, string domain)
         {
-            return DomainAutoRenewal(accountId, domain, Method.PUT);
+            return DomainAutoRenewal(accountId, domain, Method.Put);
         }
         
         /// <summary>
@@ -26,7 +26,7 @@ namespace dnsimple.Services
         /// <see>https://developer.dnsimple.com/v2/registrar/auto-renewal/#disableDomainAutoRenewal</see>
         public EmptyResponse DisableDomainAutoRenewal(long accountId, string domain)
         {
-            return DomainAutoRenewal(accountId, domain, Method.DELETE);
+            return DomainAutoRenewal(accountId, domain, Method.Delete);
         }
 
         private EmptyResponse DomainAutoRenewal(long accountId, string domain, Method method)

--- a/src/dnsimple/Services/RegistrarDelegation.cs
+++ b/src/dnsimple/Services/RegistrarDelegation.cs
@@ -37,7 +37,7 @@ namespace dnsimple.Services
         public DelegationResponse ChangeDomainDelegation(long accountId, string domain, IList<string> delegation)
         {
             var builder = BuildRequestForPath(DelegationPath(accountId, domain));
-            builder.Method(Method.PUT);
+            builder.Method(Method.Put);
             builder.AddJsonPayloadRaw(delegation);
 
             return new DelegationResponse(Execute(builder.Request));
@@ -54,7 +54,7 @@ namespace dnsimple.Services
         public ListResponse<VanityDelegation> ChangeDomainDelegationToVanity(long accountId, string domain, List<string> delegation)
         {
             var builder = BuildRequestForPath(VanityDelegationPath(accountId, domain));
-            builder.Method(Method.PUT);
+            builder.Method(Method.Put);
             builder.AddJsonPayloadRaw(delegation);
 
             return new ListResponse<VanityDelegation>(Execute(builder.Request));
@@ -69,7 +69,7 @@ namespace dnsimple.Services
         public EmptyResponse ChangeDomainDelegationFromVanity(long accountId, string domain)
         {
             var builder = BuildRequestForPath(VanityDelegationPath(accountId, domain));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }
@@ -84,7 +84,7 @@ namespace dnsimple.Services
 
         public DelegationResponse(JToken json) => Data = JsonTools<string>.DeserializeList(json);
 
-        public DelegationResponse(IRestResponse response) => Data = JsonTools<string>.DeserializeList(
+        public DelegationResponse(RestResponse response) => Data = JsonTools<string>.DeserializeList(
             JObject.Parse(response.Content)
             );
     }

--- a/src/dnsimple/Services/RegistrarTransferLock.cs
+++ b/src/dnsimple/Services/RegistrarTransferLock.cs
@@ -20,7 +20,7 @@ namespace dnsimple.Services
     public SimpleResponse<TransferLockStatus> EnableDomainTransferLock(long accountId, string domain)
     {
       var builder = BuildRequestForPath(TransferLockPath(accountId, domain));
-      builder.Method(Method.POST);
+      builder.Method(Method.Post);
 
       return new SimpleResponse<TransferLockStatus>(Execute(builder.Request));
     }
@@ -35,7 +35,7 @@ namespace dnsimple.Services
     public SimpleResponse<TransferLockStatus> DisableDomainTransferLock(long accountId, string domain)
     {
       var builder = BuildRequestForPath(TransferLockPath(accountId, domain));
-      builder.Method(Method.DELETE);
+      builder.Method(Method.Delete);
 
       return new SimpleResponse<TransferLockStatus>(Execute(builder.Request));
     }

--- a/src/dnsimple/Services/RegistrarWhoisPrivacy.cs
+++ b/src/dnsimple/Services/RegistrarWhoisPrivacy.cs
@@ -31,7 +31,7 @@ namespace dnsimple.Services
         public SimpleResponse<WhoisPrivacy> EnableWhoisPrivacy(long accountId, string domain)
         {
             var builder = BuildRequestForPath(WhoisPrivacyPath(accountId, domain));
-            builder.Method(Method.PUT);
+            builder.Method(Method.Put);
 
             return new SimpleResponse<WhoisPrivacy>(Execute(builder.Request));
         }
@@ -46,7 +46,7 @@ namespace dnsimple.Services
         public SimpleResponse<WhoisPrivacy> DisableWhoisPrivacy(long accountId, string domain)
         {
             var builder = BuildRequestForPath(WhoisPrivacyPath(accountId, domain));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new SimpleResponse<WhoisPrivacy>(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/ServiceBase.cs
+++ b/src/dnsimple/Services/ServiceBase.cs
@@ -24,7 +24,7 @@ namespace dnsimple.Services
             return Client.Http.RequestBuilder(path);
         }
 
-        protected IRestResponse Execute(RestRequest request)
+        protected RestResponse Execute(RestRequest request)
         {
             return Client.Http.Execute(request);
         }
@@ -45,12 +45,12 @@ namespace dnsimple.Services
 
     public abstract class Response
     {
-        public readonly IList<Parameter> Headers;
+        public readonly IReadOnlyCollection<HeaderParameter> Headers;
         public readonly int RateLimit;
         public readonly int RateLimitRemaining;
         public readonly int RateLimitReset;
 
-        public Response(IRestResponse response)
+        public Response(RestResponse response)
         {
             Headers = response.Headers;
             RateLimit = int.Parse(ExtractValueFromHeader("X-RateLimit-Limit"));
@@ -60,9 +60,9 @@ namespace dnsimple.Services
 
         private string ExtractValueFromHeader(string headerName)
         {
-            return (string)Headers.Where(header =>
+            return Headers.First(header =>
                     header.Name != null && header.Name.Equals(headerName, System.StringComparison.OrdinalIgnoreCase))
-                .First().Value;
+                .Value?.ToString();
         }
     }
 
@@ -72,7 +72,7 @@ namespace dnsimple.Services
     /// </summary>
     public class EmptyResponse : Response
     {
-        public EmptyResponse(IRestResponse response) : base(response)
+        public EmptyResponse(RestResponse response) : base(response)
         {
         }
     }
@@ -88,7 +88,7 @@ namespace dnsimple.Services
         /// </summary>
         public T Data { get; protected set; }
 
-        public SimpleResponse(IRestResponse response) : base(response)
+        public SimpleResponse(RestResponse response) : base(response)
         {
             Data = JsonTools<T>.DeserializeObject("data", JObject.Parse(response.Content));
         }
@@ -108,7 +108,7 @@ namespace dnsimple.Services
 
         public bool IsEmpty { get; protected set; }
 
-        public SimpleResponseOrEmpty(IRestResponse response) : base(response)
+        public SimpleResponseOrEmpty(RestResponse response) : base(response)
         {
             if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
             {
@@ -136,7 +136,7 @@ namespace dnsimple.Services
         /// </summary>
         public List<T> Data { get; }
 
-        public ListResponse(IRestResponse response) : base(response)
+        public ListResponse(RestResponse response) : base(response)
         {
             Data = JsonTools<T>.DeserializeList(JObject.Parse(response.Content));
         }
@@ -161,7 +161,7 @@ namespace dnsimple.Services
         /// <see cref="Pagination"/>
         public Pagination Pagination { get; }
 
-        public PaginatedResponse(IRestResponse response) : base(response)
+        public PaginatedResponse(RestResponse response) : base(response)
         {
             var json = JObject.Parse(response.Content);
 

--- a/src/dnsimple/Services/ServicesDomains.cs
+++ b/src/dnsimple/Services/ServicesDomains.cs
@@ -30,7 +30,7 @@ namespace dnsimple.Services
         public EmptyResponse ApplyService(long accountId, string domainIdentifier, string serviceIdentifier)
         {
             var builder = BuildRequestForPath(ApplyServicePath(accountId, domainIdentifier, serviceIdentifier));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
 
             return new EmptyResponse(Execute(builder.Request));
         }
@@ -45,7 +45,7 @@ namespace dnsimple.Services
         public EmptyResponse UnapplyService(long accountId, string domainIdentifier, string serviceIdentifier)
         {
             var builder = BuildRequestForPath(ApplyServicePath(accountId, domainIdentifier, serviceIdentifier));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
             
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/TemplateDomains.cs
+++ b/src/dnsimple/Services/TemplateDomains.cs
@@ -15,7 +15,7 @@ namespace dnsimple.Services
         public EmptyResponse ApplyTemplate(long accountId, string domainIdentifier, string templateIdentifier)
         {
             var builder = BuildRequestForPath(TemplateDomainPath(accountId, domainIdentifier, templateIdentifier));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/TemplateRecords.cs
+++ b/src/dnsimple/Services/TemplateRecords.cs
@@ -39,7 +39,7 @@ namespace dnsimple.Services
         public SimpleResponse<TemplateRecord> CreateTemplateRecord(long accountId, string template, TemplateRecord payload)
         {
             var builder = BuildRequestForPath(TemplateRecordsPath(accountId, template));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(payload);
 
             return new SimpleResponse<TemplateRecord>(Execute(builder.Request));
@@ -70,7 +70,7 @@ namespace dnsimple.Services
         public EmptyResponse DeleteTemplateRecord(long accountId, string template, long recordId)
         {
             var builder = BuildRequestForPath(TemplateRecordPath(accountId, template, recordId));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/Templates.cs
+++ b/src/dnsimple/Services/Templates.cs
@@ -46,7 +46,7 @@ namespace dnsimple.Services
         public SimpleResponse<Template> CreateTemplate(long accountId, Template template)
         {
             var builder = BuildRequestForPath(TemplatesPath(accountId));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(template);
 
             return new SimpleResponse<Template>(Execute(builder.Request));
@@ -78,7 +78,7 @@ namespace dnsimple.Services
         public SimpleResponse<Template> UpdateTemplate(long accountId, string templateIdentifier, Template payload)
         {
             var builder = BuildRequestForPath(TemplatePath(accountId, templateIdentifier));
-            builder.Method(Method.PATCH);
+            builder.Method(Method.Patch);
             builder.AddJsonPayload(payload);
 
             return new SimpleResponse<Template>(Execute(builder.Request));
@@ -93,7 +93,7 @@ namespace dnsimple.Services
         public EmptyResponse DeleteTemplate(long accountId, string templateIdentifier)
         {
             var builder = BuildRequestForPath(TemplatePath(accountId, templateIdentifier));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/VanityNameServers.cs
+++ b/src/dnsimple/Services/VanityNameServers.cs
@@ -29,7 +29,7 @@ namespace dnsimple.Services
         public ListResponse<VanityNameServer> EnableVanityNameServers(long accountId, string domain)
         {
             var builder = BuildRequestForPath(VanityNameServersPath(accountId, domain));
-            builder.Method(Method.PUT);
+            builder.Method(Method.Put);
 
             return new ListResponse<VanityNameServer>(Execute(builder.Request));
         }
@@ -42,7 +42,7 @@ namespace dnsimple.Services
         public EmptyResponse DisableVanityNameServers(long accountId, string domain)
         {
             var builder = BuildRequestForPath(VanityNameServersPath(accountId, domain));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/Webhooks.cs
+++ b/src/dnsimple/Services/Webhooks.cs
@@ -45,7 +45,7 @@ namespace dnsimple.Services
         public SimpleResponse<Webhook> CreateWebhook(long accountId, Webhook webhook)
         {
             var builder = BuildRequestForPath(WebhooksPath(accountId));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(webhook);
 
             return new SimpleResponse<Webhook>(Execute(builder.Request));
@@ -73,7 +73,7 @@ namespace dnsimple.Services
         public EmptyResponse DeleteWebhook(long accountId, long webhookId)
         {
             var builder = BuildRequestForPath(WebhookPath(accountId, webhookId));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/ZoneRecords.cs
+++ b/src/dnsimple/Services/ZoneRecords.cs
@@ -45,7 +45,7 @@ namespace dnsimple.Services
         public SimpleResponse<ZoneRecord> CreateZoneRecord(long accountId, string zoneId, ZoneRecord input)
         {
             var builder = BuildRequestForPath(ZoneRecordsPath(accountId, zoneId));
-            builder.Method(Method.POST);
+            builder.Method(Method.Post);
             builder.AddJsonPayload(PrepareRecord(input));
 
             return new SimpleResponse<ZoneRecord>(Execute(builder.Request));
@@ -87,7 +87,7 @@ namespace dnsimple.Services
         public SimpleResponse<ZoneRecord> UpdateZoneRecord(long accountId, string zoneId, long recordId, ZoneRecord record)
         {
             var builder = BuildRequestForPath(ZoneRecordPath(accountId, zoneId, recordId));
-            builder.Method(Method.PATCH);
+            builder.Method(Method.Patch);
             builder.AddJsonPayload(record);
 
             return new SimpleResponse<ZoneRecord>(Execute(builder.Request));
@@ -103,7 +103,7 @@ namespace dnsimple.Services
         public EmptyResponse DeleteZoneRecord(long accountId, string zoneId, long recordId)
         {
             var builder = BuildRequestForPath(ZoneRecordPath(accountId, zoneId, recordId));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new EmptyResponse(Execute(builder.Request));
         }

--- a/src/dnsimple/Services/Zones.cs
+++ b/src/dnsimple/Services/Zones.cs
@@ -89,7 +89,7 @@ namespace dnsimple.Services
         public SimpleResponse<Zone> ActivateDns(long accountId, string zoneName)
         {
             var builder = BuildRequestForPath(ZoneResolutionPath(accountId, zoneName));
-            builder.Method(Method.PUT);
+            builder.Method(Method.Put);
 
             return new SimpleResponse<Zone>(Execute(builder.Request));
         }
@@ -104,7 +104,7 @@ namespace dnsimple.Services
         public SimpleResponse<Zone> DeactivateDns(long accountId, string zoneName)
         {
             var builder = BuildRequestForPath(ZoneResolutionPath(accountId, zoneName));
-            builder.Method(Method.DELETE);
+            builder.Method(Method.Delete);
 
             return new SimpleResponse<Zone>(Execute(builder.Request));
         }

--- a/src/dnsimple/dnsimple.csproj
+++ b/src/dnsimple/dnsimple.csproj
@@ -29,7 +29,11 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="RestSharp" Version="106.15.0" />
+    <PackageReference Include="RestSharp" Version="114.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="dnsimple-test" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
RestSharp 106.15.0 was released in 2021. We deferred the upgrade for so long that the dependency has since undergone a full architectural rewrite. 😓 

For instance, v107 switched to `HttpClient`, removed the `IRestClient` / `IRestRequest` / `IRestResponse` interfaces, made client options immutable post-construction, renamed the `Method` enum to PascalCase, removed `JsonObject`, etc. 

This PR performs that migration in one go, keeping the public DNSimple client surface unchanged:

- Rewrote `RestClientWrapper` to own `RestClientOptions` and lazily (re)build the underlying `RestClient` whenever `BaseUrl`, `UserAgent`, or the authenticator change — required because v114 makes those immutable after construction.
- Replaced `IRestClient` / `IRestRequest` / `IRestResponse` with the concrete types throughout `HttpService`, `ServiceBase`, `RegistrarDelegation`, and all mocks/tests. `Response.Headers` is now `IReadOnlyCollection<HeaderParameter>`.
- Migrated `Credentials` to the new `IAuthenticator` contract (and the `Encoding`-aware `HttpBasicAuthenticator` constructor).
- Updated `RequestBuilder` for the v114 `RestRequest` constructor, and switched serialized-JSON payloads to `AddStringBody(..., DataFormat.Json)` to avoid double-encoding under the new `AddJsonBody(string)` overload.
- Replaced `JsonObject` (removed in v107) in `DomainsPushes` with a plain `Dictionary<string, object>`.
- Updated the `Method` enum casing (`GET` → `Get`, etc.) across all services and tests.
- Reworked `HttpTest.InvalidRequest` to exercise `HttpService.HandleExceptions` directly (exposed as `internal` with `InternalsVisibleTo dnsimple-test`), since the previous test mocked interfaces that no longer exist.

Closes #223.


## :clipboard: Deployment Pre/Post tasks

N/A


## :shipit: Deployment Verification

- [x] CI passes on this PR (build + 243 existing tests).
- [x] The next release of the `DNSimple` NuGet package installs cleanly into a consumer project and authenticates against the sandbox with an OAuth2 token.
