### PR TITLE
Remove deprecated Certificate contact_id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## main
+
+### Removed
+
+- **BREAKING**: Removed the deprecated `ContactId` field from the `Certificate` struct and from `LetsencryptCertificateAttributes`. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.
+
 ## 1.3.0 - 2026-04-15
 
 ### Added

--- a/src/dnsimple/Services/Certificates.cs
+++ b/src/dnsimple/Services/Certificates.cs
@@ -187,8 +187,6 @@ namespace dnsimple.Services
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     public struct LetsencryptCertificateAttributes
     {
-        [ObsoleteAttribute("ContactId is deprecated and its value is ignored and will be removed in the next major version.")]
-        public long? ContactId { get; set; }
         public bool AutoRenew { get; set; }
         public string Name { get; set; }
         public List<string> AlternateNames { get; set; }
@@ -203,8 +201,6 @@ namespace dnsimple.Services
     {
         public long Id { get; set; }
         public long DomainId { get; set; }
-        [ObsoleteAttribute("ContactId is deprecated and its value is ignored and will be removed in the next major version.")]
-        public long ContactId { get; set; }
         public string CommonName { get; set; }
         public long Years { get; set; }
         public string Csr { get; set; }


### PR DESCRIPTION
## Summary

Remove the deprecated `ContactId` field from the `Certificate` struct and from `LetsencryptCertificateAttributes`. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.

This is a breaking change.

Tracking PR: dnsimple/dnsimple-developer#987

## Test plan

- [x] `dotnet test` passes